### PR TITLE
Updated checkstyle from 6.11 to 6.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,13 @@
 					<configLocation>${basedir}/checkstyle.xml</configLocation>
 					<includeTestSourceDirectory>true</includeTestSourceDirectory>
 				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>6.17</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Hopefully also fixes travis build problems with checkstyle (plugin crashes with NPE for no apparent reason).
