### PR TITLE
Travis: Run newest version of jdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: java
 sudo: false
-#addons:
-#  apt:
-#    packages:
-#      - oracle-java8-installer
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
 jdk:
   - oraclejdk8
 before_install:


### PR DESCRIPTION
Travis is still running Oracle JDK8 update 31 by default, this commit changes
that to the latest version available, by having travis update to JDK8 update 91 before each build.
