### PR TITLE
Feature json tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,11 @@
 			<version>2.0.2-beta</version>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>20150729</version>
+		</dependency>
 		<dependency>
 			<groupId>com.jme3</groupId>
 			<artifactId>jme3-blender</artifactId>

--- a/src/main/java/nl/tudelft/contextproject/util/JSONUtil.java
+++ b/src/main/java/nl/tudelft/contextproject/util/JSONUtil.java
@@ -1,0 +1,52 @@
+package nl.tudelft.contextproject.util;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Create easy overhead for loading and saving of JSON objects.
+ */
+public class JSONUtil {
+
+    /**
+     * Avoid initialization.
+     */
+    private JSONUtil() {}
+
+    /**
+     * Parse a .json file to a {@link JSONObject} for easy manipulation of data.
+     * @param file - The file which one wants to load.
+     * @return - The JSONObject contained in the file.
+     * @throws IOException - File is not found.
+     */
+    public static JSONObject load(File file) throws IOException {
+        byte[] asBytes = Files.readAllBytes(file.toPath());
+        String asString = new String(asBytes, Charset.forName("UTF-8"));
+        return new JSONObject(asString);
+    }
+
+    /**
+     * Write a JSON object to a desired file.
+     * @param jsObject - The object to write.
+     * @param file - The file to write to.
+     * @throws IOException - Writing the file goes wrong.
+     * @throws JSONException - The JSON object is not in the correct format.
+     */
+    public static void save(JSONObject jsObject, File file) throws IOException, JSONException {
+        JSONObject.testValidity(jsObject);
+
+        OutputStreamWriter oWriter =
+                new OutputStreamWriter(new FileOutputStream(file), Charset.forName("UTF-8"));
+        BufferedWriter bWriter = new BufferedWriter(oWriter);
+        bWriter.write(jsObject.toString(4));
+        bWriter.close();
+    }
+}

--- a/src/main/java/nl/tudelft/contextproject/util/JSONUtil.java
+++ b/src/main/java/nl/tudelft/contextproject/util/JSONUtil.java
@@ -14,7 +14,7 @@ import org.json.JSONObject;
 /**
  * Create easy overhead for loading and saving of JSON objects.
  */
-public class JSONUtil {
+public final class JSONUtil {
 
     /**
      * Avoid initialization.

--- a/src/test/java/nl/tudelft/contextproject/util/JSONUtilTest.java
+++ b/src/test/java/nl/tudelft/contextproject/util/JSONUtilTest.java
@@ -1,0 +1,69 @@
+package nl.tudelft.contextproject.util;
+
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for the JSONUtil class.
+ */
+public class JSONUtilTest {
+
+    private JSONObject mockedJSONObject;
+    private File testFile;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+
+    /**
+     * Set up all objects used in testing.
+     */
+    @Before
+    public void setUp() {
+        mockedJSONObject = mock(JSONObject.class);
+        testFile = new File("UtilTestFile.json");
+    }
+
+    /**
+     * Remove the test file if it has been created.
+     */
+    @After
+    public void tearDown() {
+        if(testFile.exists()) {
+            testFile.delete();
+        }
+    }
+
+    /**
+     * Test for checking if an IOException occurs if one tries
+     * to load a non-existing file.
+     * @throws IOException - The expected exception.
+     */
+    @Test
+    public void testLoadFileNotFound() throws IOException {
+        thrown.expect(IOException.class);
+        File notFound = new File("NotARealFile.json");
+        JSONUtil.load(notFound);
+    }
+
+    /**
+     * Test saving of a file.
+     * @throws IOException - If file writing goes wrong.
+     */
+    @Test
+    public void testSaveFile() throws IOException {
+        when(mockedJSONObject.toString(anyInt())).thenReturn("{}");
+        JSONUtil.save(mockedJSONObject, testFile);
+    }
+}

--- a/src/test/java/nl/tudelft/contextproject/util/JSONUtilTest.java
+++ b/src/test/java/nl/tudelft/contextproject/util/JSONUtilTest.java
@@ -1,5 +1,13 @@
 package nl.tudelft.contextproject.util;
 
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
@@ -7,25 +15,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.io.File;
-import java.io.IOException;
-
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 /**
  * Test for the JSONUtil class.
  */
 public class JSONUtilTest {
 
-    private JSONObject mockedJSONObject;
-    private File testFile;
-
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
+    private JSONObject mockedJSONObject;
+    private File testFile;
 
     /**
      * Set up all objects used in testing.
@@ -42,7 +41,7 @@ public class JSONUtilTest {
      */
     @After
     public void tearDown() {
-        if(testFile.exists()) {
+        if (testFile.exists()) {
             testFile.delete();
         }
     }
@@ -59,6 +58,10 @@ public class JSONUtilTest {
         JSONUtil.load(notFound);
     }
 
+    /**
+     * Test for loading an existing file.
+     * @throws IOException - File not found.
+     */
     @Test
     public void testLoadExistingFile() throws IOException {
         JSONUtil.save(mockedJSONObject, testFile);

--- a/src/test/java/nl/tudelft/contextproject/util/JSONUtilTest.java
+++ b/src/test/java/nl/tudelft/contextproject/util/JSONUtilTest.java
@@ -10,6 +10,7 @@ import org.junit.rules.ExpectedException;
 import java.io.File;
 import java.io.IOException;
 
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,6 +34,7 @@ public class JSONUtilTest {
     public void setUp() {
         mockedJSONObject = mock(JSONObject.class);
         testFile = new File("UtilTestFile.json");
+        when(mockedJSONObject.toString(anyInt())).thenReturn("{}");
     }
 
     /**
@@ -57,13 +59,18 @@ public class JSONUtilTest {
         JSONUtil.load(notFound);
     }
 
+    @Test
+    public void testLoadExistingFile() throws IOException {
+        JSONUtil.save(mockedJSONObject, testFile);
+        assertNotNull(JSONUtil.load(testFile));
+    }
+
     /**
      * Test saving of a file.
      * @throws IOException - If file writing goes wrong.
      */
     @Test
     public void testSaveFile() throws IOException {
-        when(mockedJSONObject.toString(anyInt())).thenReturn("{}");
         JSONUtil.save(mockedJSONObject, testFile);
     }
 }


### PR DESCRIPTION
Adds an easy overhead for loading and saving JSON files. This will be used in the map generation.

Line coverage is 90%, as we can't test a private constructor and the ignore tag for cobertura isn't working.
There are no PMD warnings.
There is one FindBugs warning, namely that the result of testFile.delete() is ignored. This is fine, because the chance of this going wrong is extremely small and this file is only used for testing. This file not getting deleted won't break anything, including tests.
