### PR TITLE
Exclude certain findbugs warnings

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+<Match>
+	<!-- Ignore security issues with exposing arrays -->
+	<Bug code="EI2" />
+</Match>
+<Match>
+	<!-- Ignore exceptional return values (File.delete()) -->
+	<Bug code="RV" />
+</Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,7 @@
 					</execution>
 				</executions>
 				<configuration>
+					<excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
 					<failOnError>false</failOnError>
 					<includeTests>true</includeTests>
 					<xmlOutput>true</xmlOutput>
@@ -456,6 +457,7 @@
 				<artifactId>findbugs-maven-plugin</artifactId>
 				<version>${findbugs.version}</version>
 				<configuration>
+					<excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
 					<failOnViolation>false</failOnViolation>
 					<xmlOutput>true</xmlOutput>
 					<includeTests>true</includeTests>


### PR DESCRIPTION
Exclude warnings about exposing objects in arrays. Since we are not
creating an API, but rather a game as a whole, we can trust that the
arrays are not modified by the providing class (unless if there is a good
reason to do so). Copying the arrays would cause very large additional
memory usage without adding any functionality or security.

Exclude warnings about unusual return results like File.delete(). We want
to explicitly ignore failed deletions, as failing file deletion should not
interrupt the gameplay in any way. If the file deletion failure was
important in any way, then the error will occur when that file is
attempted to be overridden elsewhere, which is a more applicable place for
the error. (The same is true for creating directories).
