### PR TITLE
Fix link mistakes in Retrospect

### DIFF
--- a/documentation/sprint 3/Sprint 3 Retrospect.wiki
+++ b/documentation/sprint 3/Sprint 3 Retrospect.wiki
@@ -59,7 +59,7 @@ In here sprint items that were described in the backlog of this sprint are discu
 |-
 |
 
-| [https://github.com/Taeir/ContextProject-MIGI2/issues/46 #46 - Implement algorithm]
+| [https://github.com/Taeir/ContextProject-MIGI2/issues/81 #81 - Implement algorithm]
 | Bram
 | A
 | 14
@@ -69,7 +69,7 @@ In here sprint items that were described in the backlog of this sprint are discu
 |-
 |
 
-| [https://github.com/Taeir/ContextProject-MIGI2/issues/46 #46 - Make loading and saving rooms possible]
+| [https://github.com/Taeir/ContextProject-MIGI2/issues/82 #82 - Make loading and saving rooms possible]
 | Bram
 | C
 | 3
@@ -79,7 +79,7 @@ In here sprint items that were described in the backlog of this sprint are discu
 |-
 |
 
-| [https://github.com/Taeir/ContextProject-MIGI2/issues/46 #46 - Combine the features above]
+| [https://github.com/Taeir/ContextProject-MIGI2/issues/83 #83 - Combine the features above]
 | Bram
 | C
 | 1


### PR DESCRIPTION
There were a few small mistakes in the retrospect of sprint 3.
