### PR TITLE
Changed drawables to not directly inherit PhysicsObject

### DIFF
--- a/src/main/java/nl/tudelft/contextproject/controller/Controller.java
+++ b/src/main/java/nl/tudelft/contextproject/controller/Controller.java
@@ -13,6 +13,7 @@ import com.jme3.scene.Spatial;
 
 import nl.tudelft.contextproject.Main;
 import nl.tudelft.contextproject.model.Drawable;
+import nl.tudelft.contextproject.model.PhysicsObject;
 
 /**
  * Abstract class for controllers.
@@ -77,7 +78,9 @@ public abstract class Controller extends AbstractAppState {
 	 * 				The drawable to add.
 	 */
 	public void addDrawable(Drawable d) {
-		physicsEnvironment.getPhysicsSpace().add(d.getPhysicsObject());
+		if (d instanceof PhysicsObject) {
+			physicsEnvironment.getPhysicsSpace().add(((PhysicsObject) d).getPhysicsObject());
+		}
 		rootNode.attachChild(d.getSpatial());
 	}
 	

--- a/src/main/java/nl/tudelft/contextproject/model/Bomb.java
+++ b/src/main/java/nl/tudelft/contextproject/model/Bomb.java
@@ -18,7 +18,7 @@ import nl.tudelft.contextproject.Main;
 /**
  * Class representing a bomb.
  */
-public class Bomb extends Entity {
+public class Bomb extends Entity implements PhysicsObject {
 	private Geometry geometry;
 	private Spatial sp;
 

--- a/src/main/java/nl/tudelft/contextproject/model/Door.java
+++ b/src/main/java/nl/tudelft/contextproject/model/Door.java
@@ -19,7 +19,7 @@ import nl.tudelft.contextproject.Main;
 /**
  * Class representing a door.
  */
-public class Door extends Entity {
+public class Door extends Entity implements PhysicsObject {
 	private Geometry geometry;
 	private Spatial sp;
 	/**

--- a/src/main/java/nl/tudelft/contextproject/model/Drawable.java
+++ b/src/main/java/nl/tudelft/contextproject/model/Drawable.java
@@ -8,7 +8,7 @@ import com.jme3.scene.Spatial;
  * Interface representing a Drawable object.
  * This object has a geometry that can be updated.
  */
-public interface Drawable extends PhysicsObject {	
+public interface Drawable {	
 	/**
 	 * Getter for the spatial of this Drawable.
 	 * @return The spatial representing this Drawable.

--- a/src/main/java/nl/tudelft/contextproject/model/Key.java
+++ b/src/main/java/nl/tudelft/contextproject/model/Key.java
@@ -16,7 +16,7 @@ import nl.tudelft.contextproject.Main;
 /**
  * Class representing a key.
  */
-public class Key extends Entity {
+public class Key extends Entity implements PhysicsObject {
 	private Geometry geometry;
 	private Spatial sp;
 	/**

--- a/src/main/java/nl/tudelft/contextproject/model/VRPlayer.java
+++ b/src/main/java/nl/tudelft/contextproject/model/VRPlayer.java
@@ -17,7 +17,7 @@ import nl.tudelft.contextproject.Main;
 /**
  * Class representing the player wearing the VR headset.
  */
-public class VRPlayer extends Entity implements ActionListener {
+public class VRPlayer extends Entity implements ActionListener, PhysicsObject {
 	/**
 	 * Physics interaction constants.
 	 */

--- a/src/main/java/nl/tudelft/contextproject/model/level/MazeTile.java
+++ b/src/main/java/nl/tudelft/contextproject/model/level/MazeTile.java
@@ -15,11 +15,12 @@ import com.jme3.scene.shape.Box;
 
 import nl.tudelft.contextproject.Main;
 import nl.tudelft.contextproject.model.Drawable;
+import nl.tudelft.contextproject.model.PhysicsObject;
 
 /**
  * Class representing a tile in the maze.
  */
-public class MazeTile implements Drawable {
+public class MazeTile implements Drawable, PhysicsObject {
 	private Spatial spatial;
 	private Vector2f position;
 	private int height;

--- a/src/test/java/nl/tudelft/contextproject/controller/ControllerTest.java
+++ b/src/test/java/nl/tudelft/contextproject/controller/ControllerTest.java
@@ -111,11 +111,6 @@ public abstract class ControllerTest {
 			
 			@Override
 			public void setSpatial(Spatial spatial) { }
-
-			@Override
-			public PhysicsControl getPhysicsObject() {
-				return null;
-			}
 			
 			@Override
 			public void mapDraw(Graphics2D g, int resolution) { }
@@ -141,11 +136,6 @@ public abstract class ControllerTest {
 
 			@Override
 			public void setSpatial(Spatial spatial) { }
-
-			@Override
-			public PhysicsControl getPhysicsObject() {
-				return null;
-			}
 			
 			@Override
 			public void mapDraw(Graphics2D g, int resolution) { }
@@ -172,11 +162,6 @@ public abstract class ControllerTest {
 
 			@Override
 			public void setSpatial(Spatial spatial) { }
-
-			@Override
-			public PhysicsControl getPhysicsObject() {
-				return null;
-			}
 			
 			@Override
 			public void mapDraw(Graphics2D g, int resolution) { }

--- a/src/test/java/nl/tudelft/contextproject/controller/ControllerTest.java
+++ b/src/test/java/nl/tudelft/contextproject/controller/ControllerTest.java
@@ -8,7 +8,6 @@ import java.awt.Graphics2D;
 import com.jme3.app.state.AppStateManager;
 import com.jme3.bullet.BulletAppState;
 import com.jme3.bullet.PhysicsSpace;
-import com.jme3.bullet.control.PhysicsControl;
 import com.jme3.input.InputManager;
 import com.jme3.input.controls.InputListener;
 import com.jme3.light.Light;

--- a/src/test/java/nl/tudelft/contextproject/controller/GameControllerTest.java
+++ b/src/test/java/nl/tudelft/contextproject/controller/GameControllerTest.java
@@ -71,7 +71,6 @@ public class GameControllerTest extends ControllerTest {
 		PhysicsControl geom = mock(PhysicsControl.class);
 		phe = mock(BulletAppState.class);
 		PhysicsSpace phs = mock(PhysicsSpace.class);
-//		when(entity.getPhysicsObject()).thenReturn(geom);
 		when(phe.getPhysicsSpace()).thenReturn(phs);
 		
 		entities.add(entity);

--- a/src/test/java/nl/tudelft/contextproject/controller/GameControllerTest.java
+++ b/src/test/java/nl/tudelft/contextproject/controller/GameControllerTest.java
@@ -71,7 +71,7 @@ public class GameControllerTest extends ControllerTest {
 		PhysicsControl geom = mock(PhysicsControl.class);
 		phe = mock(BulletAppState.class);
 		PhysicsSpace phs = mock(PhysicsSpace.class);
-		when(entity.getPhysicsObject()).thenReturn(geom);
+//		when(entity.getPhysicsObject()).thenReturn(geom);
 		when(phe.getPhysicsSpace()).thenReturn(phs);
 		
 		entities.add(entity);

--- a/src/test/java/nl/tudelft/contextproject/controller/GameControllerTest.java
+++ b/src/test/java/nl/tudelft/contextproject/controller/GameControllerTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 import com.jme3.app.state.AppStateManager;
 import com.jme3.bullet.BulletAppState;
 import com.jme3.bullet.PhysicsSpace;
-import com.jme3.bullet.control.PhysicsControl;
 import com.jme3.input.InputManager;
 import com.jme3.input.controls.InputListener;
 import com.jme3.light.Light;
@@ -68,7 +67,6 @@ public class GameControllerTest extends ControllerTest {
 		when(entity.getSpatial()).thenReturn(mock(Spatial.class));
 		when(entity.getState()).thenReturn(EntityState.ALIVE);
 		
-		PhysicsControl geom = mock(PhysicsControl.class);
 		phe = mock(BulletAppState.class);
 		PhysicsSpace phs = mock(PhysicsSpace.class);
 		when(phe.getPhysicsSpace()).thenReturn(phs);


### PR DESCRIPTION
Now each class implementing drawable can choose to be a PhysicsObject.
This allows for entities that are not collidable.
