### PR TITLE
Switch to trusty dist for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: java
-sudo: false
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
+sudo: required
+dist: trusty
 jdk:
   - oraclejdk8
 before_install:


### PR DESCRIPTION
The trusty distribution runs on ubuntu 14.04, with at least oraclejdk1.8.0_51
installed. This means we do not have to update java before every build,
which in turn should mean that builds no longer fail randomly because
downloading java went wrong.
