### PR TITLE
Refactor test base class

### DIFF
--- a/src/test/java/nl/tudelft/contextproject/MainTest.java
+++ b/src/test/java/nl/tudelft/contextproject/MainTest.java
@@ -33,8 +33,8 @@ public class MainTest extends TestBase {
 	public void testMainStart() {
 		Main mMock = mock(Main.class);
 		Main.setInstance(mMock);
-	   Main.main(new String[0]);
-      verify(mMock, times(1)).start();
+		Main.main(new String[0]);
+		verify(mMock, times(1)).start();
 	}
 
 	/**
@@ -88,7 +88,7 @@ public class MainTest extends TestBase {
 	public void testSetController() {
 		Controller cOld = mock(Controller.class);
 		Controller c = mock(Controller.class);
-		
+
 		main.setController(cOld);
 		assertTrue(main.setController(c));
 
@@ -102,7 +102,7 @@ public class MainTest extends TestBase {
 	@Test
 	public void testSetControllerAgain() {
 		Controller c = mock(Controller.class);
-		
+
 		main.setController(c);
 		assertFalse(main.setController(c));
 	}
@@ -172,11 +172,11 @@ public class MainTest extends TestBase {
 
 		main.simpleUpdate(0.1f);
 		verify(tl, times(0)).update(0.1f);
-		
+
 		main.attachTickListener(tl);
 		main.simpleUpdate(0.1f);
 		verify(tl, times(1)).update(0.1f);
-		
+
 		main.removeTickListener(tl);
 		main.simpleUpdate(0.1f);
 		verifyNoMoreInteractions(tl);

--- a/src/test/java/nl/tudelft/contextproject/MainTest.java
+++ b/src/test/java/nl/tudelft/contextproject/MainTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 /**
  * Test suit for the Main class.
  */
-public class MainTest {
+public class MainTest extends TestBase {
 
 	private Main main;
 
@@ -33,8 +33,8 @@ public class MainTest {
 	public void testMainStart() {
 		Main mMock = mock(Main.class);
 		Main.setInstance(mMock);
-	    Main.main(new String[0]);
-        verify(mMock, times(1)).start();
+	   Main.main(new String[0]);
+      verify(mMock, times(1)).start();
 	}
 
 	/**
@@ -54,8 +54,8 @@ public class MainTest {
 		Main mMock = mock(Main.class);
 		Main.setInstance(mMock);
 		String[] args = {"a", "--debugHud", "b"};
-	    Main.main(args);
-	    assertTrue(Main.isDebugHudShown());
+	   Main.main(args);
+	   assertTrue(Main.isDebugHudShown());
 	}
 	
 	/**
@@ -66,8 +66,8 @@ public class MainTest {
 		Main mMock = mock(Main.class);
 		Main.setInstance(mMock);
 		String[] args = {"a", "--debugHudd", "b"};
-	    Main.main(args);
-	    assertFalse(Main.isDebugHudShown());
+	   Main.main(args);
+	   assertFalse(Main.isDebugHudShown());
 	}
 	
 	/**

--- a/src/test/java/nl/tudelft/contextproject/MainTest.java
+++ b/src/test/java/nl/tudelft/contextproject/MainTest.java
@@ -183,7 +183,7 @@ public class MainTest extends TestBase {
 	}
 	
 	/**
-	 * Test if seting the control mappings sets the mappings.
+	 * Test if setting the control mappings sets the mappings.
 	 */
 	@Test
 	public void testSetupControlMappings() {

--- a/src/test/java/nl/tudelft/contextproject/TestBase.java
+++ b/src/test/java/nl/tudelft/contextproject/TestBase.java
@@ -1,0 +1,59 @@
+package nl.tudelft.contextproject;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import nl.tudelft.contextproject.test.TestUtil;
+
+/**
+ * Base test class.
+ * Each test class should extend this class as it contains lines that every
+ * test class should run in @beforeClass. 
+ */
+public abstract class TestBase {
+	
+	private static Main main;
+
+	/**
+	 * Test Class setup method.
+	 * Each test class will run this method.
+	 * 
+	 * This method will do two things:
+	 * 
+	 * Firstly, it will turn off the JME logging features, so 
+	 * mocked models do not generate WARNING level logs, which makes the test output
+	 * more readable.
+	 * 
+	 * Secondly, ensures that {@link Main#getInstance()} is properly set up before any tests run.
+	 * 
+	 */
+	@BeforeClass
+	public static void setUpBeforeClass() {
+		//Set logger level
+		Logger.getLogger("com.jme3").setLevel(Level.OFF);
+
+		//Store the old Main instance
+		main = Main.getInstance();
+
+		//Clear the instance
+		Main.setInstance(null);
+
+		//Ensure the main is mocked
+		TestUtil.ensureMainMocked(true);
+	}
+
+	/**
+	 * Test Class tear down method
+	 * Restores the original Main instance after all tests are done.
+	 */
+	@AfterClass
+	public static void tearDownAfterClass() {
+		//Restore the old main
+		Main.setInstance(main);
+	}
+
+
+}

--- a/src/test/java/nl/tudelft/contextproject/audio/AudioManagerTest.java
+++ b/src/test/java/nl/tudelft/contextproject/audio/AudioManagerTest.java
@@ -4,6 +4,8 @@ import static org.mockito.Mockito.*;
 
 import com.jme3.audio.AudioNode;
 
+import nl.tudelft.contextproject.TestBase;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,7 +13,7 @@ import org.junit.Test;
 /**
  * Test class for {@link AudioManager}.
  */
-public class AudioManagerTest {
+public class AudioManagerTest extends TestBase {
 	public AudioNode an;
 	
 	/**

--- a/src/test/java/nl/tudelft/contextproject/audio/AudioTestUtil.java
+++ b/src/test/java/nl/tudelft/contextproject/audio/AudioTestUtil.java
@@ -9,11 +9,12 @@ import com.jme3.audio.Listener;
 import com.jme3.renderer.Camera;
 
 import nl.tudelft.contextproject.Main;
+import nl.tudelft.contextproject.TestBase;
 
 /**
  * Utility class for testing with audio.
  */
-public final class AudioTestUtil {
+public final class AudioTestUtil extends TestBase {
 	
 	private AudioTestUtil() { }
 	

--- a/src/test/java/nl/tudelft/contextproject/audio/BackgroundMusicTest.java
+++ b/src/test/java/nl/tudelft/contextproject/audio/BackgroundMusicTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.when;
 import com.jme3.audio.AudioNode;
 import com.jme3.audio.AudioSource.Status;
 
+import nl.tudelft.contextproject.TestBase;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -20,7 +22,7 @@ import org.junit.Test;
 /**
  * Test class for {@link BackgroundMusic}.
  */
-public class BackgroundMusicTest {
+public class BackgroundMusicTest extends TestBase {
 	public AudioNode an;
 
 	/**

--- a/src/test/java/nl/tudelft/contextproject/controller/ControllerTest.java
+++ b/src/test/java/nl/tudelft/contextproject/controller/ControllerTest.java
@@ -16,6 +16,7 @@ import com.jme3.scene.Node;
 import com.jme3.scene.Spatial;
 
 import nl.tudelft.contextproject.Main;
+import nl.tudelft.contextproject.TestBase;
 import nl.tudelft.contextproject.model.Drawable;
 
 import org.junit.Test;
@@ -23,7 +24,7 @@ import org.junit.Test;
 /**
  * Test class for the controller Class.
  */
-public abstract class ControllerTest {
+public abstract class ControllerTest extends TestBase {
 
 	/**
 	 * Get a controller to test with.

--- a/src/test/java/nl/tudelft/contextproject/controller/GameStateTest.java
+++ b/src/test/java/nl/tudelft/contextproject/controller/GameStateTest.java
@@ -4,10 +4,12 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
+import nl.tudelft.contextproject.TestBase;
+
 /**
  * Test class for the GameState enum.
  */
-public class GameStateTest {
+public class GameStateTest extends TestBase {
 
 	/**
 	 * Check that {@link GameState#ENDED} does not count as started.

--- a/src/test/java/nl/tudelft/contextproject/controller/WaitingControllerTest.java
+++ b/src/test/java/nl/tudelft/contextproject/controller/WaitingControllerTest.java
@@ -8,12 +8,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import nl.tudelft.contextproject.Main;
+import nl.tudelft.contextproject.TestBase;
 import nl.tudelft.contextproject.test.TestUtil;
 
 /**
  * Test class for the WaitingController.
  */
-public class WaitingControllerTest {
+public class WaitingControllerTest extends TestBase {
 	private static Main main;
 	private WaitingController instance;
 	

--- a/src/test/java/nl/tudelft/contextproject/logging/LogTest.java
+++ b/src/test/java/nl/tudelft/contextproject/logging/LogTest.java
@@ -15,10 +15,12 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
+import nl.tudelft.contextproject.TestBase;
+
 /**
  * Test class for {@link Log}.
  */
-public class LogTest {
+public class LogTest extends TestBase {
 
 	@Rule
 	public TemporaryFolder temp = new TemporaryFolder();

--- a/src/test/java/nl/tudelft/contextproject/model/InventoryTest.java
+++ b/src/test/java/nl/tudelft/contextproject/model/InventoryTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 import java.util.ArrayList;
 
 import nl.tudelft.contextproject.Main;
+import nl.tudelft.contextproject.TestBase;
 
 import com.jme3.asset.AssetKey;
 import com.jme3.asset.AssetManager;
@@ -24,7 +25,7 @@ import org.junit.Test;
 /**
  * Test class for the Key class.
  */
-public class InventoryTest {
+public class InventoryTest extends TestBase {
 	private Inventory inv;
 
 	/**

--- a/src/test/java/nl/tudelft/contextproject/model/entities/DrawableTest.java
+++ b/src/test/java/nl/tudelft/contextproject/model/entities/DrawableTest.java
@@ -17,7 +17,7 @@ import com.jme3.scene.Geometry;
 import com.jme3.scene.Spatial;
 
 import nl.tudelft.contextproject.Main;
-
+import nl.tudelft.contextproject.TestBase;
 import nl.tudelft.contextproject.model.Drawable;
 import org.junit.Test;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
@@ -25,7 +25,7 @@ import org.mockito.exceptions.verification.NoInteractionsWanted;
 /**
  * Abstract test class for the drawable interface.
  */
-public abstract class DrawableTest {
+public abstract class DrawableTest extends TestBase {
 
 	private Drawable dable;
 	

--- a/src/test/java/nl/tudelft/contextproject/model/level/DrawableFilterTest.java
+++ b/src/test/java/nl/tudelft/contextproject/model/level/DrawableFilterTest.java
@@ -3,6 +3,7 @@ package nl.tudelft.contextproject.model.level;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import nl.tudelft.contextproject.TestBase;
 import nl.tudelft.contextproject.model.entities.Entity;
 
 import org.junit.Before;
@@ -12,7 +13,7 @@ import org.junit.Test;
 /**
  * Testing class for the DrawableFilter class.
  */
-public class DrawableFilterTest {
+public class DrawableFilterTest extends TestBase {
 	private DrawableFilter filter;
 	private Entity e;
 

--- a/src/test/java/nl/tudelft/contextproject/model/level/GeneratorRoomTest.java
+++ b/src/test/java/nl/tudelft/contextproject/model/level/GeneratorRoomTest.java
@@ -1,6 +1,8 @@
 package nl.tudelft.contextproject.model.level;
 
 import com.jme3.math.Vector2f;
+
+import nl.tudelft.contextproject.TestBase;
 import nl.tudelft.contextproject.util.Size;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,7 +17,7 @@ import static org.mockito.Mockito.when;
  * Class for creating a GeneratorRoom.
  * This is a room only used by the generator.
  */
-public class GeneratorRoomTest {
+public class GeneratorRoomTest extends TestBase {
     private Size mockedSize;
 
     /**

--- a/src/test/java/nl/tudelft/contextproject/model/level/LevelTest.java
+++ b/src/test/java/nl/tudelft/contextproject/model/level/LevelTest.java
@@ -8,13 +8,15 @@ import java.util.List;
 
 import com.jme3.light.Light;
 
+import nl.tudelft.contextproject.TestBase;
+
 import org.junit.Before;
 import org.junit.Test;
 
 /**
  * Test class for Level.
  */
-public class LevelTest {
+public class LevelTest extends TestBase {
 
 	private Light lMock;
 	private MazeTile tMock1;

--- a/src/test/java/nl/tudelft/contextproject/model/level/RandomLevelFactoryTest.java
+++ b/src/test/java/nl/tudelft/contextproject/model/level/RandomLevelFactoryTest.java
@@ -1,5 +1,6 @@
 package nl.tudelft.contextproject.model.level;
 
+import nl.tudelft.contextproject.TestBase;
 import nl.tudelft.contextproject.util.Size;
 import org.junit.Before;
 import org.junit.Rule;
@@ -13,7 +14,7 @@ import static org.junit.Assert.*;
 /**
  * Class for testing the RandomLevelFactory.
  */
-public class RandomLevelFactoryTest {
+public class RandomLevelFactoryTest extends TestBase {
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();

--- a/src/test/java/nl/tudelft/contextproject/model/level/roomIO/EntityReaderTest.java
+++ b/src/test/java/nl/tudelft/contextproject/model/level/roomIO/EntityReaderTest.java
@@ -13,6 +13,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import nl.tudelft.contextproject.Main;
+import nl.tudelft.contextproject.TestBase;
 import nl.tudelft.contextproject.model.entities.Bomb;
 import nl.tudelft.contextproject.model.entities.Door;
 import nl.tudelft.contextproject.model.entities.Entity;
@@ -23,7 +24,7 @@ import nl.tudelft.contextproject.util.ScriptLoaderException;
 /**
  * Test class for the entityReader class.
  */
-public class EntityReaderTest {
+public class EntityReaderTest extends TestBase {
 	private static Main main;
 
 	/**

--- a/src/test/java/nl/tudelft/contextproject/model/level/roomIO/LightReaderTest.java
+++ b/src/test/java/nl/tudelft/contextproject/model/level/roomIO/LightReaderTest.java
@@ -13,10 +13,12 @@ import com.jme3.light.AmbientLight;
 import com.jme3.light.Light;
 import com.jme3.light.PointLight;
 
+import nl.tudelft.contextproject.TestBase;
+
 /**
  * Test class for the lightReader class.
  */
-public class LightReaderTest {
+public class LightReaderTest extends TestBase {
 
 	/**
 	 * Test if getting non existent light type throws an exception.

--- a/src/test/java/nl/tudelft/contextproject/model/level/roomIO/RoomReaderTest.java
+++ b/src/test/java/nl/tudelft/contextproject/model/level/roomIO/RoomReaderTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import com.jme3.light.Light;
 
 import nl.tudelft.contextproject.Main;
+import nl.tudelft.contextproject.TestBase;
 import nl.tudelft.contextproject.model.entities.Entity;
 import nl.tudelft.contextproject.model.level.MazeTile;
 import nl.tudelft.contextproject.test.TestUtil;
@@ -22,7 +23,7 @@ import nl.tudelft.contextproject.test.TestUtil;
 /**
  * Test class for the roomLoader class.
  */
-public class RoomReaderTest {
+public class RoomReaderTest extends TestBase {
 	private static Main main;
 
 	/**

--- a/src/test/java/nl/tudelft/contextproject/model/level/roomIO/TileReaderTest.java
+++ b/src/test/java/nl/tudelft/contextproject/model/level/roomIO/TileReaderTest.java
@@ -8,13 +8,14 @@ import java.io.StringReader;
 
 import org.junit.Test;
 
+import nl.tudelft.contextproject.TestBase;
 import nl.tudelft.contextproject.model.level.MazeTile;
 import nl.tudelft.contextproject.model.level.TileType;
 
 /**
  * Test class for TileReader.
  */
-public class TileReaderTest {
+public class TileReaderTest extends TestBase {
 
 	/**
 	 * Test reading an empty tile.

--- a/src/test/java/nl/tudelft/contextproject/test/TestUtil.java
+++ b/src/test/java/nl/tudelft/contextproject/test/TestUtil.java
@@ -23,6 +23,7 @@ import com.jme3.scene.Node;
 import com.jme3.system.JmeSystem;
 
 import nl.tudelft.contextproject.Main;
+import nl.tudelft.contextproject.TestBase;
 import nl.tudelft.contextproject.controller.GameState;
 import nl.tudelft.contextproject.model.Game;
 import nl.tudelft.contextproject.model.level.Level;
@@ -32,7 +33,7 @@ import nl.tudelft.contextproject.model.level.Level;
  * This class has en excessive amount of comments, as things could
  * change if we expand on our game.
  */
-public final class TestUtil {
+public final class TestUtil extends TestBase {
 	private TestUtil() { }
 	
 	/**

--- a/src/test/java/nl/tudelft/contextproject/util/EntityUtilTest.java
+++ b/src/test/java/nl/tudelft/contextproject/util/EntityUtilTest.java
@@ -2,12 +2,14 @@ package nl.tudelft.contextproject.util;
 
 import org.junit.Test;
 
+import nl.tudelft.contextproject.TestBase;
+
 import static org.junit.Assert.assertEquals;
 
 /**
  * Class for testing the EntityUtil.
  */
-public class EntityUtilTest {
+public class EntityUtilTest extends TestBase {
 
 	/**
 	 * Test getting code for Bomb.

--- a/src/test/java/nl/tudelft/contextproject/util/FileUtilTest.java
+++ b/src/test/java/nl/tudelft/contextproject/util/FileUtilTest.java
@@ -9,10 +9,12 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import nl.tudelft.contextproject.TestBase;
+
 /**
  * Test class for {@link FileUtil}.
  */
-public class FileUtilTest {
+public class FileUtilTest extends TestBase {
 	private static boolean jar;
 	private static String path;
 	private static File testFile;

--- a/src/test/java/nl/tudelft/contextproject/util/JSONUtilTest.java
+++ b/src/test/java/nl/tudelft/contextproject/util/JSONUtilTest.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import nl.tudelft.contextproject.Main;
+import nl.tudelft.contextproject.TestBase;
 import nl.tudelft.contextproject.model.entities.Bomb;
 import nl.tudelft.contextproject.model.entities.Entity;
 import nl.tudelft.contextproject.model.entities.VRPlayer;
@@ -27,7 +28,7 @@ import org.junit.rules.ExpectedException;
 /**
  * Test for the JSONUtil class.
  */
-public class JSONUtilTest {
+public class JSONUtilTest extends TestBase {
 	private static Main main;
 
 	@Rule

--- a/src/test/java/nl/tudelft/contextproject/util/QRGeneratorTest.java
+++ b/src/test/java/nl/tudelft/contextproject/util/QRGeneratorTest.java
@@ -7,11 +7,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 import nl.tudelft.contextproject.Main;
+import nl.tudelft.contextproject.TestBase;
 
 /**
  * QRGenerator test class.
  */
-public class QRGeneratorTest {
+public class QRGeneratorTest extends TestBase {
 
 	private static final String TEST_URL = "https://111.111.111.111:" + Main.PORT_NUMBER + "/";	
 	

--- a/src/test/java/nl/tudelft/contextproject/util/ReaderUtilTest.java
+++ b/src/test/java/nl/tudelft/contextproject/util/ReaderUtilTest.java
@@ -1,6 +1,9 @@
 package nl.tudelft.contextproject.util;
 
 import com.jme3.math.ColorRGBA;
+
+import nl.tudelft.contextproject.TestBase;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -9,7 +12,7 @@ import static org.junit.Assert.assertNotNull;
 /**
  * Test for the ReaderUtil class.
  */
-public class ReaderUtilTest {
+public class ReaderUtilTest extends TestBase {
 
 	/**
 	 * Test if getting a random color gives us a color.

--- a/src/test/java/nl/tudelft/contextproject/util/ScriptLoaderExceptionTest.java
+++ b/src/test/java/nl/tudelft/contextproject/util/ScriptLoaderExceptionTest.java
@@ -4,10 +4,12 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import nl.tudelft.contextproject.TestBase;
+
 /**
  * Test class for the ClassLoaderException.
  */
-public class ScriptLoaderExceptionTest {
+public class ScriptLoaderExceptionTest extends TestBase {
 
 	/**
 	 * Test if constructing with messages stores the message correctly.

--- a/src/test/java/nl/tudelft/contextproject/util/ScriptLoaderTest.java
+++ b/src/test/java/nl/tudelft/contextproject/util/ScriptLoaderTest.java
@@ -4,12 +4,14 @@ import static org.junit.Assert.*;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import nl.tudelft.contextproject.TestBase;
 import nl.tudelft.contextproject.model.TickListener;
 
 /**
  * Test class for {@link ScriptLoader}.
  */
-public class ScriptLoaderTest {
+public class ScriptLoaderTest extends TestBase {
 
 	private ScriptLoader sl;
 

--- a/src/test/java/nl/tudelft/contextproject/util/SizeTest.java
+++ b/src/test/java/nl/tudelft/contextproject/util/SizeTest.java
@@ -3,10 +3,12 @@ package nl.tudelft.contextproject.util;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
+import nl.tudelft.contextproject.TestBase;
+
 /**
  * Test for the Size class.
  */
-public class SizeTest {
+public class SizeTest extends TestBase {
 
 	/**
 	 * Test for checking the constructor and getters for Size.

--- a/src/test/java/nl/tudelft/contextproject/webinterface/WebClientTest.java
+++ b/src/test/java/nl/tudelft/contextproject/webinterface/WebClientTest.java
@@ -4,10 +4,12 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
+import nl.tudelft.contextproject.TestBase;
+
 /**
  * Test class for {@link WebClient}.
  */
-public class WebClientTest {
+public class WebClientTest extends TestBase {
 
 	/**
 	 * Tests {@link WebClient#isElf}.

--- a/src/test/java/nl/tudelft/contextproject/webinterface/WebTestBase.java
+++ b/src/test/java/nl/tudelft/contextproject/webinterface/WebTestBase.java
@@ -15,43 +15,14 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-
-import nl.tudelft.contextproject.Main;
-import nl.tudelft.contextproject.test.TestUtil;
+import nl.tudelft.contextproject.TestBase;
 
 import lombok.SneakyThrows;
 
 /**
  * Base class for the WebServer tests, with some convenience methods.
  */
-public class WebTestBase {
-	private static Main main;
-	
-	/**
-	 * Ensures that {@link Main#getInstance()} is properly set up before any tests run.
-	 */
-	@BeforeClass
-	public static void setUpBeforeClass() {
-		//STore the old Main instance
-		main = Main.getInstance();
-
-		//Clear the instance
-		Main.setInstance(null);
-
-		//Ensure the main is mocked
-		TestUtil.ensureMainMocked(true);
-	}
-
-	/**
-	 * Restores the original Main instance after all tests are done.
-	 */
-	@AfterClass
-	public static void tearDownAfterClass() {
-		//Restore the old main
-		Main.setInstance(main);
-	}
+public class WebTestBase extends TestBase {
 	
 	/**
 	 * Creates a spied session2 cookie with the given id.

--- a/src/test/java/nl/tudelft/contextproject/webinterface/WebTestBase.java
+++ b/src/test/java/nl/tudelft/contextproject/webinterface/WebTestBase.java
@@ -3,17 +3,22 @@ package nl.tudelft.contextproject.webinterface;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
 
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+
+import org.junit.BeforeClass;
 
 import nl.tudelft.contextproject.TestBase;
 
@@ -23,6 +28,25 @@ import lombok.SneakyThrows;
  * Base class for the WebServer tests, with some convenience methods.
  */
 public class WebTestBase extends TestBase {
+	
+	/**
+	 * Turn web server specific logging off.
+	 * Turns off the "webInterface" logger and the jetty logger.
+	 * 
+	 * The jetty logger is turned of by making use of Mockito as a mocked method by
+	 * default returns nothing if called, when no return statement is defined. This
+	 * causes the jetty logger to not show up in the logs during testing.
+	 */
+	@BeforeClass
+	public static void webBeforeClassSetUp() {
+		Logger.getLogger("WebInterface").setLevel(Level.OFF);
+		
+		//Create mocked logger that does nothing
+		org.eclipse.jetty.util.log.Logger noLoggerMock = mock(org.eclipse.jetty.util.log.Logger.class);
+		when(noLoggerMock.getName()).thenReturn("No logging.");
+		when(noLoggerMock.getLogger(any())).thenReturn(noLoggerMock);
+		org.eclipse.jetty.util.log.Log.setLog(noLoggerMock);
+	}
 	
 	/**
 	 * Creates a spied session2 cookie with the given id.


### PR DESCRIPTION
I created a test base class which every test class extends. The main use for this test class is to remove all unnecessary logging from Travis and Maven builds so that we can more easily read the test output.

In order to make proper use from the test Util class I also included the correct Mock of the main method, so that future test classes can use this mock instead of writing their own.

The webserver has two additional logging tools, so they had to be disabled separately.

Please look at the Travis build to see the fix in action
