### PR TITLE
Fix setController

### DIFF
--- a/src/main/java/nl/tudelft/contextproject/Main.java
+++ b/src/main/java/nl/tudelft/contextproject/Main.java
@@ -123,15 +123,13 @@ public class Main extends VRApplication {
 	 * 		true is the controller was changed, false otherwise
 	 */
 	public boolean setController(Controller c) {
-		if (c != controller) {
+		if (c != controller && c != null) {
 			if (controller != null) {
 				getStateManager().detach(controller);
 			}
 			controller = c;
+			getStateManager().attach(controller);
 			
-			if (controller != null) {
-				getStateManager().attach(controller);
-			}
 			return true;
 		}
 		return false;


### PR DESCRIPTION
Before the setController method could detach the current controller, not
set a new controller and then return true indicating a new controller
was set. As you can imagine, this won't work. This fixes that bug.
