### PR TITLE
Feature corridor beautification simple

### DIFF
--- a/src/main/java/nl/tudelft/contextproject/model/level/MSTBasedLevelFactory.java
+++ b/src/main/java/nl/tudelft/contextproject/model/level/MSTBasedLevelFactory.java
@@ -219,6 +219,7 @@ public class MSTBasedLevelFactory implements LevelFactory {
 	 * Extend the corridors and add walls to them.
 	 */
 	protected void beautifyCorridors() {
+		CorridorBeautification.simpleCorridorWidening(mazeTiles);
 		CorridorBeautification.carveCorridorWalls(mazeTiles);
 	}
 	

--- a/src/main/java/nl/tudelft/contextproject/model/level/MSTBasedLevelFactory.java
+++ b/src/main/java/nl/tudelft/contextproject/model/level/MSTBasedLevelFactory.java
@@ -12,6 +12,7 @@ import com.jme3.light.Light;
 
 import nl.tudelft.contextproject.model.entities.Entity;
 import nl.tudelft.contextproject.model.level.roomIO.MapParser;
+import nl.tudelft.contextproject.model.level.util.CorridorBeautification;
 import nl.tudelft.contextproject.model.level.util.CorridorBreadthFirstSearch;
 import nl.tudelft.contextproject.model.level.util.CorridorEdge;
 import nl.tudelft.contextproject.model.level.util.MinimumSpanningTree;
@@ -101,7 +102,7 @@ public class MSTBasedLevelFactory implements LevelFactory {
 		createEdges();
 		createReverseMST();
 		placeCorridors();
-		MSTBasedLevelFactory.carveCorridorWalls(mazeTiles);
+		beautifyCorridors();
 		for (RoomNode roomNode: usedNodes) {
 			Room room = roomNode.room;
 			entities.addAll(room.entities);
@@ -215,6 +216,13 @@ public class MSTBasedLevelFactory implements LevelFactory {
 	}	
 
 	/**
+	 * Extend the corridors and add walls to them.
+	 */
+	protected void beautifyCorridors() {
+		CorridorBeautification.carveCorridorWalls(mazeTiles);
+	}
+	
+	/**
 	 * Get all corridor locations on the map.
 	 * 
 	 * @return
@@ -230,42 +238,6 @@ public class MSTBasedLevelFactory implements LevelFactory {
 		return corridorList;
 	}
 
-	/**
-	 * This method adds walls to corridors on the map.
-	 * Checks if a Tile is a corridor, if true add a wall to all Null TileTypes.
-	 *
-	 * @param map
-	 *		the map in which to place the corridor walls
-	 */
-	protected static void carveCorridorWalls(MazeTile[][] map) {
-		int width = map.length;
-		int heigth = map[0].length;
-		for (int i = 0; i < width; i++) {
-			for (int j = 0; j < heigth; j++) {
-				if (map[i][j] != null && map[i][j].getTileType() == TileType.CORRIDOR) {
-					//Check North
-					if (j != 0 && map[i][j - 1] == null) {
-						map[i][j - 1] = new MazeTile(i, j - 1, TileType.WALL);
-					}
-
-					//Check South
-					if (j != heigth - 1 && map[i][j + 1] == null) {
-						map[i][j + 1] = new MazeTile(i, j + 1, TileType.WALL);
-					}
-
-					//Check West
-					if (i != 0 && map[i - 1][j] == null) {
-						map[i - 1][j] = new MazeTile(i - 1, j, TileType.WALL);
-					}
-
-					//Check East
-					if (i != width - 1 && map[i + 1][j] == null) {
-						map[i + 1][j] = new MazeTile(i + 1, j, TileType.WALL);
-					}
-				}
-			}
-		}
-	}
 
 	/**
 	 * Add RoomNode to graph and map.

--- a/src/main/java/nl/tudelft/contextproject/model/level/util/CorridorBeautification.java
+++ b/src/main/java/nl/tudelft/contextproject/model/level/util/CorridorBeautification.java
@@ -1,0 +1,13 @@
+package nl.tudelft.contextproject.model.level.util;
+
+/**
+ * Corridor beautifications utility class. 
+ * Class that holds some methods to enhance the single tile wide corridor creation.
+ */
+public final class CorridorBeautification {
+
+	/**
+	 * Private constructor to prevent initialization.
+	 */
+	private CorridorBeautification() {}
+}

--- a/src/main/java/nl/tudelft/contextproject/model/level/util/CorridorBeautification.java
+++ b/src/main/java/nl/tudelft/contextproject/model/level/util/CorridorBeautification.java
@@ -50,4 +50,56 @@ public final class CorridorBeautification {
 			}
 		}
 	}
+	
+	/**
+	 * Simply extend each corridor by 1 in each direction, if possible.
+	 * For this method an new maze tile map is created which holds the extra
+	 * corridors until all extra corridors have been created, this is to prevent
+	 * placing extra corridors on extra corridors, filling the entire map with corridors.
+	 * <p>
+	 * This method can be called after each other on the same map to keep extending the corridors
+	 * by 1 extra corridor tile in each direction.
+	 * 
+	 * @param map
+	 *		the map in which to place the corridor tiles
+	 */
+	public static void simpleCorridorWidening(MazeTile[][] map) {
+		int width = map.length;
+		int heigth = map[0].length;
+		MazeTile[][] extraCorridorMap = new MazeTile[heigth][width];
+		
+		//Add new corridors if possible to the extraCorridorMap
+		for (int i = 0; i < width; i++) {
+			for (int j = 0; j < heigth; j++) {
+				if (map[i][j] != null && map[i][j].getTileType() == TileType.CORRIDOR) {
+					//Check North
+					if (j != 0 && map[i][j - 1] == null) {
+						extraCorridorMap[i][j - 1] = new MazeTile(i, j - 1, TileType.CORRIDOR);
+					}
+
+					//Check South
+					if (j != heigth - 1 && map[i][j + 1] == null) {
+						extraCorridorMap[i][j + 1] = new MazeTile(i, j + 1, TileType.CORRIDOR);
+					}
+
+					//Check West
+					if (i != 0 && map[i - 1][j] == null) {
+						extraCorridorMap[i - 1][j] = new MazeTile(i - 1, j, TileType.CORRIDOR);
+					}
+
+					//Check East
+					if (i != width - 1 && map[i + 1][j] == null) {
+						extraCorridorMap[i + 1][j] = new MazeTile(i + 1, j, TileType.CORRIDOR);
+					}
+				}
+			}
+		}
+		
+		//Add all extra corridor tiles to actual map
+		for (int i = 0; i < width; i++) {
+			for (int j = 0; j < heigth; j++) {
+				if (extraCorridorMap[i][j] != null) map[i][j] = new MazeTile(i, j, TileType.CORRIDOR);
+			}
+		}
+	}
 }

--- a/src/main/java/nl/tudelft/contextproject/model/level/util/CorridorBeautification.java
+++ b/src/main/java/nl/tudelft/contextproject/model/level/util/CorridorBeautification.java
@@ -1,5 +1,8 @@
 package nl.tudelft.contextproject.model.level.util;
 
+import nl.tudelft.contextproject.model.level.MazeTile;
+import nl.tudelft.contextproject.model.level.TileType;
+
 /**
  * Corridor beautifications utility class. 
  * Class that holds some methods to enhance the single tile wide corridor creation.
@@ -10,4 +13,41 @@ public final class CorridorBeautification {
 	 * Private constructor to prevent initialization.
 	 */
 	private CorridorBeautification() {}
+	
+	/**
+	 * This method adds walls to corridors on the map.
+	 * Checks if a Tile is a corridor, if true add a wall to all Null TileTypes.
+	 *
+	 * @param map
+	 *		the map in which to place the corridor walls
+	 */
+	public static void carveCorridorWalls(MazeTile[][] map) {
+		int width = map.length;
+		int heigth = map[0].length;
+		for (int i = 0; i < width; i++) {
+			for (int j = 0; j < heigth; j++) {
+				if (map[i][j] != null && map[i][j].getTileType() == TileType.CORRIDOR) {
+					//Check North
+					if (j != 0 && map[i][j - 1] == null) {
+						map[i][j - 1] = new MazeTile(i, j - 1, TileType.WALL);
+					}
+
+					//Check South
+					if (j != heigth - 1 && map[i][j + 1] == null) {
+						map[i][j + 1] = new MazeTile(i, j + 1, TileType.WALL);
+					}
+
+					//Check West
+					if (i != 0 && map[i - 1][j] == null) {
+						map[i - 1][j] = new MazeTile(i - 1, j, TileType.WALL);
+					}
+
+					//Check East
+					if (i != width - 1 && map[i + 1][j] == null) {
+						map[i + 1][j] = new MazeTile(i + 1, j, TileType.WALL);
+					}
+				}
+			}
+		}
+	}
 }

--- a/src/test/java/nl/tudelft/contextproject/model/level/MSTBasedLevelFactoryTest.java
+++ b/src/test/java/nl/tudelft/contextproject/model/level/MSTBasedLevelFactoryTest.java
@@ -2,7 +2,6 @@ package nl.tudelft.contextproject.model.level;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -51,127 +50,7 @@ public class MSTBasedLevelFactoryTest extends TestBase {
 		assertNotNull(factoryMST.mazeTiles);
 	}
 
-	/**
-	 * Test if a corridor North of a tile is carved correctly.
-	 */
-	@Test
-	public void testCarveCorridorNorthCorrect() {
-		MazeTile[][] testMap = new MazeTile[1][2];
-		testMap[0][1] = new MazeTile(0, 1, TileType.CORRIDOR);
-		MSTBasedLevelFactory.carveCorridorWalls(testMap);
-		assertEquals(TileType.WALL, testMap[0][0].getTileType());
-	}
 	
-	/**
-	 * Test if a corridor North of a tile is not carved if not possible.
-	 */
-	@Test
-	public void testCarveCorridorNorthAlreadyFilled() {
-		MazeTile[][] testMap = new MazeTile[1][2];
-		testMap[0][0] = new MazeTile(0, 0, TileType.FLOOR);
-		testMap[0][1] = new MazeTile(0, 1, TileType.CORRIDOR);
-		MSTBasedLevelFactory.carveCorridorWalls(testMap);
-		assertEquals(TileType.FLOOR, testMap[0][0].getTileType());
-	}
-	
-	/**
-	 * Test if a corridor North of a tile is carved correctly.
-	 */
-	@Test
-	public void testCarveCorridorSouthCorrect() {
-		MazeTile[][] testMap = new MazeTile[1][2];
-		testMap[0][0] = new MazeTile(0, 0, TileType.CORRIDOR);
-		MSTBasedLevelFactory.carveCorridorWalls(testMap);
-		assertEquals(TileType.WALL, testMap[0][1].getTileType());
-	}
-	
-	/**
-	 * Test if a corridor South of a tile is not carved if not possible.
-	 */
-	@Test
-	public void testCarveCorridorSouthAlreadyFilled() {
-		MazeTile[][] testMap = new MazeTile[1][2];
-		testMap[0][1] = new MazeTile(0, 1, TileType.FLOOR);
-		testMap[0][0] = new MazeTile(0, 0, TileType.CORRIDOR);
-		MSTBasedLevelFactory.carveCorridorWalls(testMap);
-		assertEquals(TileType.FLOOR, testMap[0][1].getTileType());
-	}
-	
-	/**
-	 * Test if a corridor West of a tile is carved correctly.
-	 */
-	@Test
-	public void testCarveCorridorWestCorrect() {
-		MazeTile[][] testMap = new MazeTile[2][1];
-		testMap[1][0] = new MazeTile(1, 0, TileType.CORRIDOR);
-		MSTBasedLevelFactory.carveCorridorWalls(testMap);
-		assertEquals(TileType.WALL, testMap[0][0].getTileType());
-	}
-	
-	/**
-	 * Test if a corridor West of a tile is not carved if not possible.
-	 */
-	@Test
-	public void testCarveCorridorWestAlreadyFilled() {
-		MazeTile[][] testMap = new MazeTile[2][1];
-		testMap[0][0] = new MazeTile(0, 0, TileType.FLOOR);
-		testMap[1][0] = new MazeTile(1, 0, TileType.CORRIDOR);
-		MSTBasedLevelFactory.carveCorridorWalls(testMap);
-		assertEquals(TileType.FLOOR, testMap[0][0].getTileType());
-	}
-	
-	/**
-	 * Test if a corridor East of a tile is carved correctly.
-	 */
-	@Test
-	public void testCarveCorridorEastCorrect() {
-		MazeTile[][] testMap = new MazeTile[2][1];
-		testMap[0][0] = new MazeTile(0, 0, TileType.CORRIDOR);
-		MSTBasedLevelFactory.carveCorridorWalls(testMap);
-		assertEquals(TileType.WALL, testMap[1][0].getTileType());
-	}
-	
-	/**
-	 * Test if a corridor East of a tile is not carved if not possible.
-	 */
-	@Test
-	public void testCarveCorridorEastAlreadyFilled() {
-		MazeTile[][] testMap = new MazeTile[2][1];
-		testMap[1][0] = new MazeTile(1, 0, TileType.FLOOR);
-		testMap[0][0] = new MazeTile(0, 0, TileType.CORRIDOR);
-		MSTBasedLevelFactory.carveCorridorWalls(testMap);
-		assertEquals(TileType.FLOOR, testMap[1][0].getTileType());
-	}
-	
-	/**
-	 * Test if corridor carving does nothing if corridor is one edge of the map.
-	 */
-	@Test
-	public void testCarveCorridorAllDirectionsNotPossible() {
-		MazeTile[][] testMap1 = new MazeTile[1][1];
-		MazeTile[][] testMap2 = new MazeTile[1][1];
-		testMap1[0][0] = new MazeTile(0, 0, TileType.CORRIDOR);
-		testMap2[0][0] = new MazeTile(0, 0, TileType.CORRIDOR);
-		MSTBasedLevelFactory.carveCorridorWalls(testMap1);
-		assertTrue(equalTileTypeMap(testMap2, testMap1));
-	}
-	
-	/**
-	 * Test if carving happens in all directions at the same time.
-	 * Note that this shouldn't happen in game as it will close in the player, however
-	 * this method should still make this possible.
-	 */
-	@Test
-	public void testCarveCorridorAllDirections() {
-		MazeTile[][] testMap1 = createBaseTileTypeMap();
-		MazeTile[][] testMap2 = createBaseTileTypeMap();
-		MSTBasedLevelFactory.carveCorridorWalls(testMap1);
-		testMap2[0][1] = new MazeTile(0, 1, TileType.WALL);
-		testMap2[1][0] = new MazeTile(1, 0, TileType.WALL);
-		testMap2[1][2] = new MazeTile(1, 2, TileType.WALL);
-		testMap2[2][1] = new MazeTile(2, 1, TileType.WALL);
-		assertTrue(equalTileTypeMap(testMap2, testMap1));
-	}
 
 	/**
 	 * Test the map creation with a simple map folder.

--- a/src/test/java/nl/tudelft/contextproject/model/level/util/CorridorBeautificationTest.java
+++ b/src/test/java/nl/tudelft/contextproject/model/level/util/CorridorBeautificationTest.java
@@ -1,0 +1,186 @@
+package nl.tudelft.contextproject.model.level.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import nl.tudelft.contextproject.model.level.MazeTile;
+import nl.tudelft.contextproject.model.level.TileType;
+
+/**
+ * Test class for corridor beautification.
+ */
+public class CorridorBeautificationTest {
+
+	/**
+	 * Test if a corridor North of a tile is carved correctly.
+	 */
+	@Test
+	public void testCarveCorridorNorthCorrect() {
+		MazeTile[][] testMap = new MazeTile[1][2];
+		testMap[0][1] = new MazeTile(0, 1, TileType.CORRIDOR);
+		CorridorBeautification.carveCorridorWalls(testMap);
+		assertEquals(TileType.WALL, testMap[0][0].getTileType());
+	}
+	
+	/**
+	 * Test if a corridor North of a tile is not carved if not possible.
+	 */
+	@Test
+	public void testCarveCorridorNorthAlreadyFilled() {
+		MazeTile[][] testMap = new MazeTile[1][2];
+		testMap[0][0] = new MazeTile(0, 0, TileType.FLOOR);
+		testMap[0][1] = new MazeTile(0, 1, TileType.CORRIDOR);
+		CorridorBeautification.carveCorridorWalls(testMap);
+		assertEquals(TileType.FLOOR, testMap[0][0].getTileType());
+	}
+	
+	/**
+	 * Test if a corridor North of a tile is carved correctly.
+	 */
+	@Test
+	public void testCarveCorridorSouthCorrect() {
+		MazeTile[][] testMap = new MazeTile[1][2];
+		testMap[0][0] = new MazeTile(0, 0, TileType.CORRIDOR);
+		CorridorBeautification.carveCorridorWalls(testMap);
+		assertEquals(TileType.WALL, testMap[0][1].getTileType());
+	}
+	
+	/**
+	 * Test if a corridor South of a tile is not carved if not possible.
+	 */
+	@Test
+	public void testCarveCorridorSouthAlreadyFilled() {
+		MazeTile[][] testMap = new MazeTile[1][2];
+		testMap[0][1] = new MazeTile(0, 1, TileType.FLOOR);
+		testMap[0][0] = new MazeTile(0, 0, TileType.CORRIDOR);
+		CorridorBeautification.carveCorridorWalls(testMap);
+		assertEquals(TileType.FLOOR, testMap[0][1].getTileType());
+	}
+	
+	/**
+	 * Test if a corridor West of a tile is carved correctly.
+	 */
+	@Test
+	public void testCarveCorridorWestCorrect() {
+		MazeTile[][] testMap = new MazeTile[2][1];
+		testMap[1][0] = new MazeTile(1, 0, TileType.CORRIDOR);
+		CorridorBeautification.carveCorridorWalls(testMap);
+		assertEquals(TileType.WALL, testMap[0][0].getTileType());
+	}
+	
+	/**
+	 * Test if a corridor West of a tile is not carved if not possible.
+	 */
+	@Test
+	public void testCarveCorridorWestAlreadyFilled() {
+		MazeTile[][] testMap = new MazeTile[2][1];
+		testMap[0][0] = new MazeTile(0, 0, TileType.FLOOR);
+		testMap[1][0] = new MazeTile(1, 0, TileType.CORRIDOR);
+		CorridorBeautification.carveCorridorWalls(testMap);
+		assertEquals(TileType.FLOOR, testMap[0][0].getTileType());
+	}
+	
+	/**
+	 * Test if a corridor East of a tile is carved correctly.
+	 */
+	@Test
+	public void testCarveCorridorEastCorrect() {
+		MazeTile[][] testMap = new MazeTile[2][1];
+		testMap[0][0] = new MazeTile(0, 0, TileType.CORRIDOR);
+		CorridorBeautification.carveCorridorWalls(testMap);
+		assertEquals(TileType.WALL, testMap[1][0].getTileType());
+	}
+	
+	/**
+	 * Test if a corridor East of a tile is not carved if not possible.
+	 */
+	@Test
+	public void testCarveCorridorEastAlreadyFilled() {
+		MazeTile[][] testMap = new MazeTile[2][1];
+		testMap[1][0] = new MazeTile(1, 0, TileType.FLOOR);
+		testMap[0][0] = new MazeTile(0, 0, TileType.CORRIDOR);
+		CorridorBeautification.carveCorridorWalls(testMap);
+		assertEquals(TileType.FLOOR, testMap[1][0].getTileType());
+	}
+	
+	/**
+	 * Test if corridor carving does nothing if corridor is one edge of the map.
+	 */
+	@Test
+	public void testCarveCorridorAllDirectionsNotPossible() {
+		MazeTile[][] testMap1 = new MazeTile[1][1];
+		MazeTile[][] testMap2 = new MazeTile[1][1];
+		testMap1[0][0] = new MazeTile(0, 0, TileType.CORRIDOR);
+		testMap2[0][0] = new MazeTile(0, 0, TileType.CORRIDOR);
+		CorridorBeautification.carveCorridorWalls(testMap1);
+		assertTrue(equalTileTypeMap(testMap2, testMap1));
+	}
+	
+	/**
+	 * Test if carving happens in all directions at the same time.
+	 * Note that this shouldn't happen in game as it will close in the player, however
+	 * this method should still make this possible.
+	 */
+	@Test
+	public void testCarveCorridorAllDirections() {
+		MazeTile[][] testMap1 = createBaseTileTypeMap();
+		MazeTile[][] testMap2 = createBaseTileTypeMap();
+		CorridorBeautification.carveCorridorWalls(testMap1);
+		testMap2[0][1] = new MazeTile(0, 1, TileType.WALL);
+		testMap2[1][0] = new MazeTile(1, 0, TileType.WALL);
+		testMap2[1][2] = new MazeTile(1, 2, TileType.WALL);
+		testMap2[2][1] = new MazeTile(2, 1, TileType.WALL);
+		assertTrue(equalTileTypeMap(testMap2, testMap1));
+	}
+	
+	/**
+	 * Test if two equaltileTypesMap are the same.
+	 * Does not check for null or maps of size zero.
+	 * 
+	 * @param map1
+	 * 		how the map should look like
+	 * @param map2
+	 * 		the map that is checked
+	 * @return
+	 * 		boolean true if map1 == map2
+	 */
+	public boolean equalTileTypeMap(MazeTile[][] map1, MazeTile[][] map2) {
+		int width = map1.length;
+		int height = map1[0].length;
+		if (width != map2.length || height != map2[0].length) {
+			return false;
+		}
+		MazeTile mazeTile1, mazeTile2;
+		for (int i = 0; i < width; i++) {
+			for (int j = 0; j < height; j++) {
+				mazeTile1 = map1[i][j];
+				mazeTile2 = map2[i][j];
+				if (mazeTile1 == null && mazeTile2 == null) {
+					continue;
+				}
+				if (mazeTile1 != null && map2[i][j] == null
+					|| map1[i][j] == null && map2[i][j] != null
+					&& map1[i][j].getTileType() != map2[i][j].getTileType()) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+	
+	/**
+	 * Create a basic TileType map with a corridor.
+	 * 
+	 * @return
+	 * 		a 3 by 3 map which looks like NNN, NCN, NNN where N is null and C a corridor TileType
+	 */
+	public MazeTile[][] createBaseTileTypeMap() {
+		MazeTile[][] map = new MazeTile[3][3];
+		map[1][1] = new MazeTile(1, 1, TileType.CORRIDOR);
+		return map;
+	}
+
+}


### PR DESCRIPTION
Moved some responsibility from the MSTBasedLevelFactory related to corridor beautification to the new CorridorBeautification utility class.

Added a method that widens corridors if possible, so that the corridors are wider.
[Here is a shot of a small map with no duplicate chambers with the wider corridors](https://gyazo.com/120336cf87ff2f479f62aeae37123b79)
[Here is a shot of a large map with duplicate chambers with the wider corridors](https://gyazo.com/eb1438edd43cd03c1c705f062285d444)

Since corridor beautification that created noise to the corridors will take more time then expected, this simple fix will have to do for the gameplay testing tomorrow. I think the corridors look slightly boring like this, but it should be less nausea inducing to play the game.
