### PR TITLE
[Optimize] Webconnection

### DIFF
--- a/src/main/java/nl/tudelft/contextproject/Main.java
+++ b/src/main/java/nl/tudelft/contextproject/Main.java
@@ -134,6 +134,8 @@ public class Main extends VRApplication implements Observable {
 		if (this.controller != null) {
 			getStateManager().detach(this.controller);
 		}
+		
+		GameState oldState = getGameState();
 
 		this.controller = newController;
 		getStateManager().attach(this.controller);
@@ -141,6 +143,11 @@ public class Main extends VRApplication implements Observable {
 		if (webServer != null) {
 			webServer.clearCooldowns();
 			webServer.getInventory().reset();
+			
+			//When switching from the ENDED state to the WAITING state, kick all clients
+			if (oldState == GameState.ENDED && getGameState() == GameState.WAITING) {
+				webServer.disconnectAll();
+			}
 		}
 		
 		return true;

--- a/src/main/java/nl/tudelft/contextproject/controller/GameState.java
+++ b/src/main/java/nl/tudelft/contextproject/controller/GameState.java
@@ -36,7 +36,7 @@ public enum GameState {
 	 * 		true if the state represents a started game, false otherwise
 	 */
 	public boolean isStarted() {
-		return this == RUNNING || this == PAUSED;
+		return this == RUNNING || this == PAUSED || this == ENDED;
 	}
 }
 

--- a/src/main/java/nl/tudelft/contextproject/webinterface/NormalHandler.java
+++ b/src/main/java/nl/tudelft/contextproject/webinterface/NormalHandler.java
@@ -403,31 +403,31 @@ public class NormalHandler {
 		GameState state = main.getGameState();
 		
 		JSONObject json = new JSONObject();
-		json.put("team", client.getTeam().ordinal());
-		json.put("state", state.ordinal());
+		json.put("t", client.getTeam().ordinal());
+		json.put("s", state.ordinal());
 		
 		switch (state) {
 			case TUTORIAL:
 				break;
 			case WAITING:
-				json.put("dwarfs", server.getDwarfsCount());
-				json.put("elves", server.getElvesCount());
+				json.put("dc", server.getDwarfsCount());
+				json.put("ec", server.getElvesCount());
 				
 				//Fall through to running
 			case RUNNING:
-				json.put("entities", EntityUtil.entitiesToJson(game.getEntities(), game.getPlayer()));
-				json.put("inventory", server.getInventory().toWebJson(client.getTeam()));
+				json.put("e", EntityUtil.entitiesToJson(game.getEntities(), game.getPlayer()));
+				json.put("i", server.getInventory().toWebJson(client.getTeam()));
 				if (client.isElf()) {
-					json.put("explored", game.getLevel().toExploredWebJSON());
+					json.put("x", game.getLevel().toExploredWebJSON());
 				}
-				json.put("timer", game.getTimeRemaining());
+				json.put("r", game.getTimeRemaining());
 				break;
 			case PAUSED:
 				//We don't send any other data when the game is paused
 				break;
 			case ENDED:
 				Boolean elvesWin = ((EndingController) main.getController()).didElvesWin();
-				json.put("winner", elvesWin);
+				json.put("w", elvesWin);
 				break;
 			default:
 				break;

--- a/src/main/java/nl/tudelft/contextproject/webinterface/WebClient.java
+++ b/src/main/java/nl/tudelft/contextproject/webinterface/WebClient.java
@@ -145,8 +145,8 @@ public class WebClient {
 	public void sendMessage(JSONObject msg, HttpServletResponse response) throws IOException {
 		if (response == null) {
 			COCSocket socket = this.webSocket;
-			if (socket != null && socket.isConnected()) {
-				socket.getRemote().sendStringByFuture(msg.toString());
+			if (socket != null) {
+				socket.sendMessage(msg.toString());
 			}
 		} else {
 			response.setStatus(HttpStatus.OK_200);
@@ -168,8 +168,8 @@ public class WebClient {
 	public void sendMessage(String msg, HttpServletResponse response) throws IOException {
 		if (response == null) {
 			COCSocket socket = this.webSocket;
-			if (socket != null && socket.isConnected()) {
-				socket.getRemote().sendStringByFuture(msg);
+			if (socket != null) {
+				socket.sendMessage(msg);
 			}
 		} else {
 			response.setStatus(HttpStatus.OK_200);

--- a/src/main/java/nl/tudelft/contextproject/webinterface/WebServer.java
+++ b/src/main/java/nl/tudelft/contextproject/webinterface/WebServer.java
@@ -1,5 +1,7 @@
 package nl.tudelft.contextproject.webinterface;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -13,6 +15,7 @@ import nl.tudelft.contextproject.webinterface.websockets.COCWebSocketServlet;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.websocket.api.StatusCode;
 
 /**
  * Class to run the web interface.
@@ -175,6 +178,27 @@ public class WebServer {
 		if (socket != null) socket.getSession().close(statusCode, null);
 		
 		clients.values().remove(client);
+	}
+	
+	/**
+	 * Disconnects all clients.
+	 */
+	public void disconnectAll() {
+		List<COCSocket> sockets = new ArrayList<>();
+		for (WebClient client : clients.values()) {
+			COCSocket socket = client.getWebSocket();
+			if (socket != null) {
+				sockets.add(socket);
+			}
+		}
+		
+		clients.clear();
+		
+		for (COCSocket socket : sockets) {
+			if (socket.isConnected()) {
+				socket.getSession().close(StatusCode.NORMAL, null);
+			}
+		}
 	}
 	
 	/**

--- a/src/main/java/nl/tudelft/contextproject/webinterface/websockets/COCSocket.java
+++ b/src/main/java/nl/tudelft/contextproject/webinterface/websockets/COCSocket.java
@@ -22,6 +22,7 @@ import lombok.SneakyThrows;
  */
 public class COCSocket extends WebSocketAdapter implements Observer {
 	public static final float UPDATE_INTERVAL = 0.15f;
+	public static final long TIMEOUT = 10_000;
 	
 	private final WebServer server;
 	private final WebClient client;
@@ -103,8 +104,14 @@ public class COCSocket extends WebSocketAdapter implements Observer {
 		
 		timer += tpf;
 		if (timer < UPDATE_INTERVAL) return;
-		
 		timer = 0f;
+		
+		//Kick clients from the the game after a timeout.
+		if (Main.getInstance().getGameState() == GameState.WAITING && System.currentTimeMillis() - lastMessage > TIMEOUT) {
+			server.disconnect(client, StatusCode.NORMAL);
+			return;
+		}
+		
 		server.getNormalHandler().sendStatusUpdate(client, null);
 	}
 	

--- a/src/main/java/nl/tudelft/contextproject/webinterface/websockets/COCSocket.java
+++ b/src/main/java/nl/tudelft/contextproject/webinterface/websockets/COCSocket.java
@@ -92,9 +92,15 @@ public class COCSocket extends WebSocketAdapter implements Observer {
 	@Override
 	public void onWebSocketClose(int statusCode, String reason) {
 		super.onWebSocketClose(statusCode, reason);
-
+		
 		Main.getInstance().removeObserver(this);
 		this.client.removeWebSocket(this);
+		
+		//Remove the client if they drop in the waiting state
+		if (Main.getInstance().getGameState() == GameState.WAITING) {
+			server.getClients().values().remove(client);
+			return;
+		}
 	}
 
 	@SneakyThrows(IOException.class)

--- a/src/main/java/nl/tudelft/contextproject/webinterface/websockets/COCWebSocketServlet.java
+++ b/src/main/java/nl/tudelft/contextproject/webinterface/websockets/COCWebSocketServlet.java
@@ -9,11 +9,7 @@ import nl.tudelft.contextproject.webinterface.WebServer;
  * Servlet class to handle client requests to create WebSockets.
  */
 public class COCWebSocketServlet extends WebSocketServlet {
-
 	private static final long serialVersionUID = -3247862472092878820L;
-
-	//The client timeout in milliseconds
-	private static final long CLIENT_TIMEOUT = 10_000L;
 	
 	private final transient WebServer server;
 	
@@ -29,7 +25,6 @@ public class COCWebSocketServlet extends WebSocketServlet {
 
 	@Override
 	public void configure(WebSocketServletFactory factory) {
-		factory.getPolicy().setIdleTimeout(CLIENT_TIMEOUT);
 		factory.register(COCSocket.class);
 		factory.setCreator(new COCWebSocketCreator(server));
 	}

--- a/src/main/resources/webinterface/js/handlers.js
+++ b/src/main/resources/webinterface/js/handlers.js
@@ -89,10 +89,10 @@ function handleStatusUpdateMessage(data) {
     }
     
     //Update the team
-    updateTeam(Teams[data.team]);
+    updateTeam(Teams[data.t]);
     
     //Switch to the correct view
-    switchTo(GameStates[data.state].view);
+    switchTo(GameStates[data.s].view);
     
     //Update the game with the received information
     updateGame(data);

--- a/src/main/resources/webinterface/js/updates.js
+++ b/src/main/resources/webinterface/js/updates.js
@@ -14,17 +14,17 @@ var gWidth = 0;
  *      the status data sent from the server
  */
 function updateGame(data) {
-    var state = GameStates[data.state];
+    var state = GameStates[data.s];
     switch (state.name) {
         case "RUNNING":
         case "WAITING":
-            updateEntities(data.entities);
-            updateTimer(data.timer);
+            updateEntities(data.e);
+            updateTimer(data.r);
             
-            if (Teams[data.team] === "DWARFS") {
+            if (Teams[data.t] === "DWARFS") {
                 exploreAll();
-            } else if (data.explored !== undefined) {
-                updateExplored(data.explored);
+            } else if (data.x !== undefined) {
+                updateExplored(data.x);
             }
             break;
         case "ENDED":

--- a/src/test/java/nl/tudelft/contextproject/controller/GameStateTest.java
+++ b/src/test/java/nl/tudelft/contextproject/controller/GameStateTest.java
@@ -12,11 +12,11 @@ import nl.tudelft.contextproject.TestBase;
 public class GameStateTest extends TestBase {
 
 	/**
-	 * Check that {@link GameState#ENDED} does not count as started.
+	 * Check that {@link GameState#ENDED} does count as started.
 	 */
 	@Test
 	public void testIsStartedENDED() {
-		assertFalse(GameState.ENDED.isStarted());
+		assertTrue(GameState.ENDED.isStarted());
 	}
 	
 	/**

--- a/src/test/java/nl/tudelft/contextproject/webinterface/NormalHandlerTest.java
+++ b/src/test/java/nl/tudelft/contextproject/webinterface/NormalHandlerTest.java
@@ -655,8 +655,8 @@ public class NormalHandlerTest extends WebTestBase {
 		ArgumentCaptor<JSONObject> ac = ArgumentCaptor.forClass(JSONObject.class);
 		verify(client).sendMessage(ac.capture(), eq(response));
 		
-		assertEquals(GameState.RUNNING.ordinal(), ac.getValue().getInt("state"));
-		assertEquals(Team.ELVES.ordinal(), ac.getValue().getInt("team"));
+		assertEquals(GameState.RUNNING.ordinal(), ac.getValue().getInt("s"));
+		assertEquals(Team.ELVES.ordinal(), ac.getValue().getInt("t"));
 	}
 
 	/**

--- a/src/test/java/nl/tudelft/contextproject/webinterface/WebClientTest.java
+++ b/src/test/java/nl/tudelft/contextproject/webinterface/WebClientTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.http.HttpStatus;
-import org.eclipse.jetty.websocket.api.RemoteEndpoint;
 import org.json.JSONObject;
 import org.junit.Test;
 
@@ -102,15 +101,13 @@ public class WebClientTest extends WebTestBase {
 	@Test
 	public void testSendMessage_socket() throws IOException {
 		COCSocket socket = mock(COCSocket.class);
-		when(socket.getRemote()).thenReturn(mock(RemoteEndpoint.class));
-		when(socket.isConnected()).thenReturn(true);
 		
 		WebClient client = new WebClient();
 		client.setWebSocket(socket);
 		
 		client.sendMessage("A", null);
 		
-		verify(socket.getRemote()).sendStringByFuture("A");
+		verify(socket).sendMessage("A");
 	}
 	
 	/**
@@ -144,8 +141,6 @@ public class WebClientTest extends WebTestBase {
 	@Test
 	public void testSendMessage_json_socket() throws IOException {
 		COCSocket socket = mock(COCSocket.class);
-		when(socket.getRemote()).thenReturn(mock(RemoteEndpoint.class));
-		when(socket.isConnected()).thenReturn(true);
 		
 		WebClient client = new WebClient();
 		client.setWebSocket(socket);
@@ -154,7 +149,7 @@ public class WebClientTest extends WebTestBase {
 		
 		client.sendMessage(json, null);
 		
-		verify(socket.getRemote()).sendStringByFuture(json.toString());
+		verify(socket).sendMessage(json.toString());
 	}
 	
 	/**

--- a/src/test/java/nl/tudelft/contextproject/webinterface/WebServerTest.java
+++ b/src/test/java/nl/tudelft/contextproject/webinterface/WebServerTest.java
@@ -275,6 +275,7 @@ public class WebServerTest extends WebTestBase {
 	public void testDisconnectAll() {
 		COCSocket socket = mock(COCSocket.class);
 		when(socket.getSession()).thenReturn(mock(Session.class));
+		when(socket.isConnected()).thenReturn(true);
 		
 		WebClient client1 = new WebClient();
 		WebClient client2 = new WebClient();

--- a/src/test/java/nl/tudelft/contextproject/webinterface/WebServerTest.java
+++ b/src/test/java/nl/tudelft/contextproject/webinterface/WebServerTest.java
@@ -1,14 +1,13 @@
 package nl.tudelft.contextproject.webinterface;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 
 import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.StatusCode;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -257,6 +256,7 @@ public class WebServerTest extends WebTestBase {
 	public void testDisconnect() {
 		COCSocket socket = mock(COCSocket.class);
 		when(socket.getSession()).thenReturn(mock(Session.class));
+		when(socket.isConnected()).thenReturn(true);
 		
 		WebClient client = new WebClient();
 		client.setWebSocket(socket);
@@ -266,5 +266,25 @@ public class WebServerTest extends WebTestBase {
 		
 		verify(socket.getSession()).close(10, null);
 		assertFalse(webServer.getClients().containsValue(client));
+	}
+	
+	/**
+	 * Tests if {@link WebServer#disconnectAll} properly disconnects all clients.
+	 */
+	@Test
+	public void testDisconnectAll() {
+		COCSocket socket = mock(COCSocket.class);
+		when(socket.getSession()).thenReturn(mock(Session.class));
+		
+		WebClient client1 = new WebClient();
+		WebClient client2 = new WebClient();
+		client1.setWebSocket(socket);
+		client2.setWebSocket(socket);
+		
+		webServer.getClients().put("A", client1);
+		webServer.getClients().put("B", client2);
+		
+		verify(socket.getSession(), times(2)).close(StatusCode.NORMAL, null);
+		assertTrue(webServer.getClients().isEmpty());
 	}
 }

--- a/src/test/java/nl/tudelft/contextproject/webinterface/WebServerTest.java
+++ b/src/test/java/nl/tudelft/contextproject/webinterface/WebServerTest.java
@@ -284,6 +284,8 @@ public class WebServerTest extends WebTestBase {
 		webServer.getClients().put("A", client1);
 		webServer.getClients().put("B", client2);
 		
+		webServer.disconnectAll();
+		
 		verify(socket.getSession(), times(2)).close(StatusCode.NORMAL, null);
 		assertTrue(webServer.getClients().isEmpty());
 	}


### PR DESCRIPTION
- Kick clients after the game has ended, to prevent further problems.
- Mark the ENDED state as "isStarted". This means that clients cannot join while the game is on the ended menu.
- Kick clients from the game if they drop out in the waiting state.
- Optimize the status update messages to use less characters.
