### PR TITLE
Refactor keep unit interfaces small

### DIFF
--- a/src/main/java/nl/tudelft/contextproject/model/level/roomIO/RoomParser.java
+++ b/src/main/java/nl/tudelft/contextproject/model/level/roomIO/RoomParser.java
@@ -16,7 +16,7 @@ import nl.tudelft.contextproject.util.FileUtil;
 import nl.tudelft.contextproject.model.entities.Entity;
 import nl.tudelft.contextproject.model.level.MazeTile;
 import nl.tudelft.contextproject.util.ScriptLoaderException;
-import nl.tudelft.contextproject.util.Vec2I;
+import nl.tudelft.contextproject.util.Size;
 
 /**
  * Utility class for loading rooms/levels from file.
@@ -60,7 +60,7 @@ public final class RoomParser {
 			int height = Integer.parseInt(tmp[1]);
 			checkDimensions(width, height, tiles);
 			
-			TileParser.readTiles(tiles, new Vec2I(width, height), br);
+			TileParser.readTiles(tiles, new Size(width, height), br);
 
 			try {
 				EntityParser.readEntities(entities, Integer.parseInt(tmp[2]), br, folder);

--- a/src/main/java/nl/tudelft/contextproject/model/level/roomIO/RoomParser.java
+++ b/src/main/java/nl/tudelft/contextproject/model/level/roomIO/RoomParser.java
@@ -16,6 +16,7 @@ import nl.tudelft.contextproject.util.FileUtil;
 import nl.tudelft.contextproject.model.entities.Entity;
 import nl.tudelft.contextproject.model.level.MazeTile;
 import nl.tudelft.contextproject.util.ScriptLoaderException;
+import nl.tudelft.contextproject.util.Vec2I;
 
 /**
  * Utility class for loading rooms/levels from file.
@@ -59,7 +60,7 @@ public final class RoomParser {
 			int height = Integer.parseInt(tmp[1]);
 			checkDimensions(width, height, tiles);
 			
-			TileParser.readTiles(tiles, width, height, br);
+			TileParser.readTiles(tiles, new Vec2I(width, height), br);
 
 			try {
 				EntityParser.readEntities(entities, Integer.parseInt(tmp[2]), br, folder);

--- a/src/main/java/nl/tudelft/contextproject/model/level/roomIO/TileParser.java
+++ b/src/main/java/nl/tudelft/contextproject/model/level/roomIO/TileParser.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 
 import nl.tudelft.contextproject.model.level.MazeTile;
 import nl.tudelft.contextproject.model.level.TileType;
+import nl.tudelft.contextproject.util.Vec2I;
 
 /**
  * Utility class for reading MazeTiles.
@@ -51,27 +52,21 @@ public final class TileParser {
 	 *
 	 * @param tiles
 	 * 		the array to store the tiles in
-	 * @param width
-	 * 		the width of the array to read
-	 * @param height
-	 * 		the height of the array to read
-	 * @param xOffset
-	 * 		the horizontal offset to apply on the tiles
-	 * @param yOffset
-	 * 		the vertical offset to apply to the tiles
+	 * @param size
+	 * 		the size of the map. The x represents the width and the y represents the height
 	 * @param br
 	 * 		the BufferedReader used to get the input
 	 * @throws IOException
 	 * 		when reading from the reader goes wrong
 	 */
-	public static void readTiles(MazeTile[][] tiles, int width, int height, BufferedReader br) throws IOException {
-		for (int y = 0; y < height; y++) {
+	public static void readTiles(MazeTile[][] tiles, Vec2I size, BufferedReader br) throws IOException {
+		for (int y = 0; y < size.y; y++) {
 			String in = br.readLine();
 			if (in == null) throw new IllegalArgumentException("Empty line where some data was expected when loading tile row " + y + ".");
 
 			String[] line = in.split(" ");
-			if (line.length < width) {
-				throw new IllegalArgumentException("There are not enoug tiles in this row! expected " + width + ", but was " + line.length + ".");
+			if (line.length < size.x) {
+				throw new IllegalArgumentException("There are not enoug tiles in this row! expected " + size.x + ", but was " + line.length + ".");
 			}
 
 			for (int x = 0; x < line.length; x++) {

--- a/src/main/java/nl/tudelft/contextproject/model/level/roomIO/TileParser.java
+++ b/src/main/java/nl/tudelft/contextproject/model/level/roomIO/TileParser.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 
 import nl.tudelft.contextproject.model.level.MazeTile;
 import nl.tudelft.contextproject.model.level.TileType;
-import nl.tudelft.contextproject.util.Vec2I;
+import nl.tudelft.contextproject.util.Size;
 
 /**
  * Utility class for reading MazeTiles.
@@ -53,20 +53,20 @@ public final class TileParser {
 	 * @param tiles
 	 * 		the array to store the tiles in
 	 * @param size
-	 * 		the size of the map. The x represents the width and the y represents the height
+	 * 		the size of the map
 	 * @param br
 	 * 		the BufferedReader used to get the input
 	 * @throws IOException
 	 * 		when reading from the reader goes wrong
 	 */
-	public static void readTiles(MazeTile[][] tiles, Vec2I size, BufferedReader br) throws IOException {
-		for (int y = 0; y < size.y; y++) {
+	public static void readTiles(MazeTile[][] tiles, Size size, BufferedReader br) throws IOException {
+		for (int y = 0; y < size.getHeight(); y++) {
 			String in = br.readLine();
 			if (in == null) throw new IllegalArgumentException("Empty line where some data was expected when loading tile row " + y + ".");
 
 			String[] line = in.split(" ");
-			if (line.length < size.x) {
-				throw new IllegalArgumentException("There are not enoug tiles in this row! expected " + size.x + ", but was " + line.length + ".");
+			if (line.length < size.getWidth()) {
+				throw new IllegalArgumentException("There are not enoug tiles in this row! expected " + size.getWidth() + ", but was " + line.length + ".");
 			}
 
 			for (int x = 0; x < line.length; x++) {

--- a/src/main/java/nl/tudelft/contextproject/webinterface/NormalHandler.java
+++ b/src/main/java/nl/tudelft/contextproject/webinterface/NormalHandler.java
@@ -336,7 +336,7 @@ public class NormalHandler {
 			return;
 		}
 
-		if (!WebUtil.checkValidLocation(location.x, location.y, action)) {
+		if (!WebUtil.checkValidLocation(location, action)) {
 			client.sendMessage(COCErrorCode.ACTION_ILLEGAL_LOCATION.toString(), response);
 			return;
 		}

--- a/src/main/java/nl/tudelft/contextproject/webinterface/NormalHandler.java
+++ b/src/main/java/nl/tudelft/contextproject/webinterface/NormalHandler.java
@@ -352,7 +352,7 @@ public class NormalHandler {
 		}
 
 		try {
-			ActionUtil.perform(action, location.x, location.y);
+			ActionUtil.perform(action, location);
 			if (response != null) {
 				client.confirmMessage(response);
 			}

--- a/src/main/java/nl/tudelft/contextproject/webinterface/util/ActionUtil.java
+++ b/src/main/java/nl/tudelft/contextproject/webinterface/util/ActionUtil.java
@@ -11,6 +11,7 @@ import nl.tudelft.contextproject.model.entities.VoidPlatform;
 import nl.tudelft.contextproject.model.entities.exploding.Bomb;
 import nl.tudelft.contextproject.model.entities.exploding.LandMine;
 import nl.tudelft.contextproject.model.entities.moving.KillerBunny;
+import nl.tudelft.contextproject.util.Vec2I;
 import nl.tudelft.contextproject.webinterface.Action;
 
 /**
@@ -33,12 +34,13 @@ public final class ActionUtil {
 	 *
 	 * @param action
 	 * 		the action to perform
-	 * @param xCoord
-	 * 		the x coordinate to perform the action on
-	 * @param yCoord
-	 * 		the y coordinate to perform the action on
+	 * @param location
+	 * 		the location to perform the action at
 	 */
-	public static void perform(Action action, int xCoord, int yCoord) {
+	public static void perform(Action action, Vec2I location) {
+		int xCoord = location.x;
+		int yCoord = location.y;
+		
 		switch (action) {
 			case PLACEBOMB:
 				placeBomb(xCoord, yCoord);

--- a/src/main/java/nl/tudelft/contextproject/webinterface/util/WebUtil.java
+++ b/src/main/java/nl/tudelft/contextproject/webinterface/util/WebUtil.java
@@ -44,7 +44,7 @@ public final class WebUtil {
 	/**
 	 * Check if a location is a valid location to perform an action on.
 	 *
-	 * @param xCoord
+	 * @param location
 	 * 		the location to check
 	 * @param action
 	 * 		the action to check for

--- a/src/main/java/nl/tudelft/contextproject/webinterface/util/WebUtil.java
+++ b/src/main/java/nl/tudelft/contextproject/webinterface/util/WebUtil.java
@@ -6,6 +6,7 @@ import nl.tudelft.contextproject.model.entities.Entity;
 import nl.tudelft.contextproject.model.entities.moving.VRPlayer;
 import nl.tudelft.contextproject.model.level.MazeTile;
 import nl.tudelft.contextproject.model.level.TileType;
+import nl.tudelft.contextproject.util.Vec2I;
 import nl.tudelft.contextproject.webinterface.Action;
 import nl.tudelft.contextproject.webinterface.Team;
 import nl.tudelft.contextproject.webinterface.WebClient;
@@ -44,24 +45,22 @@ public final class WebUtil {
 	 * Check if a location is a valid location to perform an action on.
 	 *
 	 * @param xCoord
-	 * 		the x coordinate of the location
-	 * @param yCoord
-	 * 		the y coordinate of the location
+	 * 		the location to check
 	 * @param action
 	 * 		the action to check for
 	 * @return
 	 * 		true if the location is valid, false otherwise
 	 */
-	public static boolean checkValidLocation(int xCoord, int yCoord, Action action) {
-		MazeTile tile = Main.getInstance().getCurrentGame().getLevel().getTile(xCoord, yCoord);
+	public static boolean checkValidLocation(Vec2I location, Action action) {
+		MazeTile tile = Main.getInstance().getCurrentGame().getLevel().getTile(location.x, location.y);
 		if (tile == null && action.isAllowedVoid()) {
-			return checkValidLocationEntities(xCoord, yCoord);
+			return checkValidLocationEntities(location.x, location.y);
 		} else if (tile == null || tile.getTileType() == TileType.WALL) {
 			return false;
 		}
 
 		if (action.isAllowedTiles()) {
-			return checkValidLocationEntities(xCoord, yCoord);
+			return checkValidLocationEntities(location.x, location.y);
 		}
 
 		return false;

--- a/src/test/java/nl/tudelft/contextproject/model/level/roomIO/TileParserTest.java
+++ b/src/test/java/nl/tudelft/contextproject/model/level/roomIO/TileParserTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import nl.tudelft.contextproject.TestBase;
 import nl.tudelft.contextproject.model.level.MazeTile;
 import nl.tudelft.contextproject.model.level.TileType;
-import nl.tudelft.contextproject.util.Vec2I;
+import nl.tudelft.contextproject.util.Size;
 
 /**
  * Test class for TileReader.
@@ -29,7 +29,7 @@ public class TileParserTest extends TestBase {
 		MazeTile[][] tiles = new MazeTile[1][1];
 		String input = TileParser.EMPTY_FORMAT;
 		BufferedReader br = new BufferedReader(new StringReader(input));
-		TileParser.readTiles(tiles, new Vec2I(1, 1), br);
+		TileParser.readTiles(tiles, new Size(1, 1), br);
 		assertNull(tiles[0][0]);
 	}
 	
@@ -44,7 +44,7 @@ public class TileParserTest extends TestBase {
 		MazeTile[][] tiles = new MazeTile[1][1];
 		String input = TileParser.WALL_FORMAT;
 		BufferedReader br = new BufferedReader(new StringReader(input));
-		TileParser.readTiles(tiles, new Vec2I(1, 1), br);
+		TileParser.readTiles(tiles, new Size(1, 1), br);
 		assertEquals(TileType.WALL, tiles[0][0].getTileType());
 	}
 	
@@ -59,7 +59,7 @@ public class TileParserTest extends TestBase {
 		MazeTile[][] tiles = new MazeTile[1][1];
 		String input = TileParser.CORRIDOR_FORMAT;
 		BufferedReader br = new BufferedReader(new StringReader(input));
-		TileParser.readTiles(tiles, new Vec2I(1, 1), br);
+		TileParser.readTiles(tiles, new Size(1, 1), br);
 		assertEquals(TileType.CORRIDOR, tiles[0][0].getTileType());
 	}
 	
@@ -74,7 +74,7 @@ public class TileParserTest extends TestBase {
 		MazeTile[][] tiles = new MazeTile[1][1];
 		String input = TileParser.FLOOR_FORMAT;
 		BufferedReader br = new BufferedReader(new StringReader(input));
-		TileParser.readTiles(tiles, new Vec2I(1, 1), br);
+		TileParser.readTiles(tiles, new Size(1, 1), br);
 		assertEquals(TileType.FLOOR, tiles[0][0].getTileType());
 	}
 	
@@ -89,7 +89,7 @@ public class TileParserTest extends TestBase {
 		MazeTile[][] tiles = new MazeTile[1][1];
 		String in = "THIS_TILETYPE_DOES_NOT_EXIST";
 		BufferedReader br = new BufferedReader(new StringReader(in));
-		TileParser.readTiles(tiles, new Vec2I(1, 1), br);
+		TileParser.readTiles(tiles, new Size(1, 1), br);
 	}
 	
 	/**
@@ -103,7 +103,7 @@ public class TileParserTest extends TestBase {
 		MazeTile[][] tiles = new MazeTile[1][1];
 		String in = TileParser.FLOOR_FORMAT;
 		BufferedReader br = new BufferedReader(new StringReader(in));
-		TileParser.readTiles(tiles, new Vec2I(2, 1), br);
+		TileParser.readTiles(tiles, new Size(2, 1), br);
 	}
 	
 	/**
@@ -117,7 +117,7 @@ public class TileParserTest extends TestBase {
 		MazeTile[][] tiles = new MazeTile[1][1];
 		String in = "FLOOR";
 		BufferedReader br = new BufferedReader(new StringReader(in));
-		TileParser.readTiles(tiles, new Vec2I(1, 2), br);
+		TileParser.readTiles(tiles, new Size(1, 2), br);
 	}
 	
 	/**

--- a/src/test/java/nl/tudelft/contextproject/model/level/roomIO/TileParserTest.java
+++ b/src/test/java/nl/tudelft/contextproject/model/level/roomIO/TileParserTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import nl.tudelft.contextproject.TestBase;
 import nl.tudelft.contextproject.model.level.MazeTile;
 import nl.tudelft.contextproject.model.level.TileType;
+import nl.tudelft.contextproject.util.Vec2I;
 
 /**
  * Test class for TileReader.
@@ -28,7 +29,7 @@ public class TileParserTest extends TestBase {
 		MazeTile[][] tiles = new MazeTile[1][1];
 		String input = TileParser.EMPTY_FORMAT;
 		BufferedReader br = new BufferedReader(new StringReader(input));
-		TileParser.readTiles(tiles, 1, 1, br);
+		TileParser.readTiles(tiles, new Vec2I(1, 1), br);
 		assertNull(tiles[0][0]);
 	}
 	
@@ -43,7 +44,7 @@ public class TileParserTest extends TestBase {
 		MazeTile[][] tiles = new MazeTile[1][1];
 		String input = TileParser.WALL_FORMAT;
 		BufferedReader br = new BufferedReader(new StringReader(input));
-		TileParser.readTiles(tiles, 1, 1, br);
+		TileParser.readTiles(tiles, new Vec2I(1, 1), br);
 		assertEquals(TileType.WALL, tiles[0][0].getTileType());
 	}
 	
@@ -58,7 +59,7 @@ public class TileParserTest extends TestBase {
 		MazeTile[][] tiles = new MazeTile[1][1];
 		String input = TileParser.CORRIDOR_FORMAT;
 		BufferedReader br = new BufferedReader(new StringReader(input));
-		TileParser.readTiles(tiles, 1, 1, br);
+		TileParser.readTiles(tiles, new Vec2I(1, 1), br);
 		assertEquals(TileType.CORRIDOR, tiles[0][0].getTileType());
 	}
 	
@@ -73,7 +74,7 @@ public class TileParserTest extends TestBase {
 		MazeTile[][] tiles = new MazeTile[1][1];
 		String input = TileParser.FLOOR_FORMAT;
 		BufferedReader br = new BufferedReader(new StringReader(input));
-		TileParser.readTiles(tiles, 1, 1, br);
+		TileParser.readTiles(tiles, new Vec2I(1, 1), br);
 		assertEquals(TileType.FLOOR, tiles[0][0].getTileType());
 	}
 	
@@ -88,7 +89,7 @@ public class TileParserTest extends TestBase {
 		MazeTile[][] tiles = new MazeTile[1][1];
 		String in = "THIS_TILETYPE_DOES_NOT_EXIST";
 		BufferedReader br = new BufferedReader(new StringReader(in));
-		TileParser.readTiles(tiles, 1, 1, br);
+		TileParser.readTiles(tiles, new Vec2I(1, 1), br);
 	}
 	
 	/**
@@ -102,7 +103,7 @@ public class TileParserTest extends TestBase {
 		MazeTile[][] tiles = new MazeTile[1][1];
 		String in = TileParser.FLOOR_FORMAT;
 		BufferedReader br = new BufferedReader(new StringReader(in));
-		TileParser.readTiles(tiles, 2, 1, br);
+		TileParser.readTiles(tiles, new Vec2I(2, 1), br);
 	}
 	
 	/**
@@ -116,7 +117,7 @@ public class TileParserTest extends TestBase {
 		MazeTile[][] tiles = new MazeTile[1][1];
 		String in = "FLOOR";
 		BufferedReader br = new BufferedReader(new StringReader(in));
-		TileParser.readTiles(tiles, 1, 2, br);
+		TileParser.readTiles(tiles, new Vec2I(1, 2), br);
 	}
 	
 	/**

--- a/src/test/java/nl/tudelft/contextproject/webinterface/util/ActionUtilTest.java
+++ b/src/test/java/nl/tudelft/contextproject/webinterface/util/ActionUtilTest.java
@@ -19,6 +19,7 @@ import nl.tudelft.contextproject.model.entities.exploding.Bomb;
 import nl.tudelft.contextproject.model.entities.exploding.LandMine;
 import nl.tudelft.contextproject.model.entities.moving.KillerBunny;
 import nl.tudelft.contextproject.test.TestUtil;
+import nl.tudelft.contextproject.util.Vec2I;
 import nl.tudelft.contextproject.webinterface.Action;
 
 /**
@@ -41,7 +42,7 @@ public class ActionUtilTest extends TestBase {
 	 */
 	@Test
 	public void testPerformPlaceBomb() {
-		ActionUtil.perform(Action.PLACEBOMB, 0, 0);
+		ActionUtil.perform(Action.PLACEBOMB, new Vec2I(0, 0));
 		verify(Main.getInstance(), times(1)).getCurrentGame();
 		verify(mockedGame, times(1)).addEntity(any(Bomb.class));
 	}
@@ -51,7 +52,7 @@ public class ActionUtilTest extends TestBase {
 	 */
 	@Test
 	public void testPerformPlacePitfall() {
-		ActionUtil.perform(Action.PLACEPITFALL, 0, 0);
+		ActionUtil.perform(Action.PLACEPITFALL, new Vec2I(0, 0));
 		verify(Main.getInstance(), times(1)).getCurrentGame();
 		verify(mockedGame, times(1)).addEntity(any(Pitfall.class));
 	}
@@ -61,7 +62,7 @@ public class ActionUtilTest extends TestBase {
 	 */
 	@Test
 	public void testPerformPlaceMine() {
-		ActionUtil.perform(Action.PLACEMINE, 0, 0);
+		ActionUtil.perform(Action.PLACEMINE, new Vec2I(0, 0));
 		verify(Main.getInstance(), times(1)).getCurrentGame();
 		verify(mockedGame, times(1)).addEntity(any(LandMine.class));
 	}
@@ -71,7 +72,7 @@ public class ActionUtilTest extends TestBase {
 	 */
 	@Test
 	public void testPerformSpawnEnemy() {
-		ActionUtil.perform(Action.SPAWNENEMY, 0, 0);
+		ActionUtil.perform(Action.SPAWNENEMY, new Vec2I(0, 0));
 		verify(mockedGame, times(1)).addEntity(any(KillerBunny.class));
 	}
 
@@ -80,7 +81,7 @@ public class ActionUtilTest extends TestBase {
 	 */
 	@Test
 	public void testPerformDropBait() {
-		ActionUtil.perform(Action.DROPBAIT, 0, 0);
+		ActionUtil.perform(Action.DROPBAIT, new Vec2I(0, 0));
 		verify(Main.getInstance(), times(1)).getCurrentGame();
 		verify(mockedGame, times(1)).addEntity(any(Carrot.class));
 	}
@@ -90,7 +91,7 @@ public class ActionUtilTest extends TestBase {
 	 */
 	@Test
 	public void testPerformPlaceTile() {
-		ActionUtil.perform(Action.PLACETILE, 0, 0);
+		ActionUtil.perform(Action.PLACETILE, new Vec2I(0, 0));
 		verify(Main.getInstance(), times(1)).getCurrentGame();
 		verify(mockedGame, times(1)).addEntity(any(VoidPlatform.class));
 	}
@@ -100,7 +101,7 @@ public class ActionUtilTest extends TestBase {
 	 */
 	@Test
 	public void testPerformDropCrate() {
-		ActionUtil.perform(Action.DROPCRATE, 0, 0);
+		ActionUtil.perform(Action.DROPCRATE, new Vec2I(0, 0));
 		verify(Main.getInstance(), times(1)).getCurrentGame();
 		verify(mockedGame, times(1)).addEntity(any(Crate.class));
 	}
@@ -116,7 +117,7 @@ public class ActionUtilTest extends TestBase {
 		when(gate.getLocation()).thenReturn(new Vector3f());
 		
 		Main.getInstance().getCurrentGame().addEntity(gate);
-		ActionUtil.perform(Action.OPENGATE, 0, 0);
+		ActionUtil.perform(Action.OPENGATE, new Vec2I(0, 0));
 		verify(gate, atLeastOnce()).openGate();
 	}
 }

--- a/src/test/java/nl/tudelft/contextproject/webinterface/util/WebUtilTest.java
+++ b/src/test/java/nl/tudelft/contextproject/webinterface/util/WebUtilTest.java
@@ -10,6 +10,7 @@ import nl.tudelft.contextproject.model.entities.moving.VRPlayer;
 import nl.tudelft.contextproject.model.level.Level;
 import nl.tudelft.contextproject.model.level.MazeTile;
 import nl.tudelft.contextproject.model.level.TileType;
+import nl.tudelft.contextproject.util.Vec2I;
 import nl.tudelft.contextproject.webinterface.Action;
 import nl.tudelft.contextproject.webinterface.Team;
 import nl.tudelft.contextproject.webinterface.WebClient;
@@ -69,7 +70,7 @@ public class WebUtilTest extends TestBase {
 	@Test
 	public void testCheckValidLocationNull() {
 		when(mockedLevel.getTile(0, 0)).thenReturn(null);
-		assertFalse(WebUtil.checkValidLocation(0, 0, Action.PLACEBOMB));
+		assertFalse(WebUtil.checkValidLocation(new Vec2I(0, 0), Action.PLACEBOMB));
 	}
 
 	/**
@@ -79,7 +80,7 @@ public class WebUtilTest extends TestBase {
 	public void testCheckValidLocationWall() {
 		MazeTile tile = new MazeTile(0, 0, TileType.WALL);
 		when(mockedLevel.getTile(0, 0)).thenReturn(tile);
-		assertFalse(WebUtil.checkValidLocation(0, 0, Action.PLACEBOMB));
+		assertFalse(WebUtil.checkValidLocation(new Vec2I(0, 0), Action.PLACEBOMB));
 	}
 
 	/**
@@ -98,7 +99,7 @@ public class WebUtilTest extends TestBase {
 
 		when(mockedGame.getEntities()).thenReturn(entities);
 
-		assertFalse(WebUtil.checkValidLocation(0, 0, Action.PLACEBOMB));
+		assertFalse(WebUtil.checkValidLocation(new Vec2I(0, 0), Action.PLACEBOMB));
 	}
 
 	/**
@@ -142,7 +143,7 @@ public class WebUtilTest extends TestBase {
 		Vector3f oneVector = new Vector3f(1, 1, 1);
 		when(mockedPlayer.getLocation()).thenReturn(oneVector);
 
-		assertTrue(WebUtil.checkValidLocation(0, 0, Action.PLACETILE));
+		assertTrue(WebUtil.checkValidLocation(new Vec2I(0, 0), Action.PLACETILE));
 	}
 
 	/**
@@ -222,6 +223,6 @@ public class WebUtilTest extends TestBase {
 		when(mockedGame.getPlayer()).thenReturn(mockedPlayer);
 		when(mockedPlayer.getLocation()).thenReturn(oneVector);
 		
-		assertFalse(WebUtil.checkValidLocation(1 + Action.PLACEMINE.getRadius(), 1, Action.PLACEMINE));
+		assertFalse(WebUtil.checkValidLocation(new Vec2I(1 + Action.PLACEMINE.getRadius(), 1), Action.PLACEMINE));
 	}
 }


### PR DESCRIPTION
Apply SIG's "Keep Unit Interfaces Small", by using Vec2I instead of 2 ints for locations and sizes.
