### PR TITLE
Optimize web communication

### DIFF
--- a/src/main/java/nl/tudelft/contextproject/webinterface/NormalHandler.java
+++ b/src/main/java/nl/tudelft/contextproject/webinterface/NormalHandler.java
@@ -439,6 +439,11 @@ public class NormalHandler {
 		if (client.isElf()) {
 			json.put("x", game.getLevel().toExploredWebJSON());
 		}
-		json.put("r", game.getTimeRemaining());
+		
+		if (game.getTimeRemaining() > 9999) {
+			json.put("r", 9999);
+		} else {
+			json.put("r", Math.round(game.getTimeRemaining()));
+		}
 	}
 }

--- a/src/main/java/nl/tudelft/contextproject/webinterface/util/EntityUtil.java
+++ b/src/main/java/nl/tudelft/contextproject/webinterface/util/EntityUtil.java
@@ -3,7 +3,6 @@ package nl.tudelft.contextproject.webinterface.util;
 import java.util.Set;
 
 import org.json.JSONArray;
-import org.json.JSONObject;
 
 import nl.tudelft.contextproject.model.entities.Entity;
 import nl.tudelft.contextproject.model.entities.exploding.Bomb;
@@ -34,31 +33,31 @@ public final class EntityUtil {
 		for (Entity entity : entities) {
 			if (entity.getType().getWebId() == 0) continue;
 			
-			JSONObject entityJson = entityToJson(entity);
+			JSONArray entityJson = entityToJson(entity);
 			jArray.put(entityJson);
 		}
 
-		JSONObject entityJson = entityToJson(player);
+		JSONArray entityJson = entityToJson(player);
 		jArray.put(entityJson);
 
 		return jArray;
 	}
 
 	/**
-	 * Turn one entity into a json object.
+	 * Turn one entity into a json array.
 	 *
 	 * @param entity
-	 * 		the entity to turn into a json
+	 * 		the entity to turn into json
 	 * @return
 	 * 		the json
 	 */
-	protected static JSONObject entityToJson(Entity entity) {
-		JSONObject json = new JSONObject();
-		json.put("x", Math.round(entity.getLocation().getX()));
-		json.put("y", Math.round(entity.getLocation().getZ()));
-		json.put("t", entity.getType().getWebId());
+	protected static JSONArray entityToJson(Entity entity) {
+		JSONArray json = new JSONArray();
+		json.put(entity.getType().getWebId());
+		json.put(Math.round(entity.getLocation().getX()));
+		json.put(Math.round(entity.getLocation().getZ()));
 		if (entity instanceof Bomb) {
-			json.put("d", Math.round(((Bomb) entity).getTimer()));
+			json.put(Math.round(((Bomb) entity).getTimer()));
 		}
 		return json;
 	}

--- a/src/main/resources/webinterface/js/updates.js
+++ b/src/main/resources/webinterface/js/updates.js
@@ -273,10 +273,10 @@ function updateEntities(data) {
         if (gEntities !== null) {
             //Remove the old data
             for (var i = 0, len = gEntities.length; i < len; i++) {
-                var type = EntityTypes[gEntities[i].t];
+                var type = EntityTypes[gEntities[i][0]];
                 if (type === undefined) continue;
                 
-                var element = document.getElementById("y" + gEntities[i].y + "x" + gEntities[i].x);
+                var element = document.getElementById("y" + gEntities[i][2] + "x" + gEntities[i][1]);
                 if (element == null) continue;
                 
                 element.classList.remove(type);
@@ -287,25 +287,25 @@ function updateEntities(data) {
         }
         
         for (var i = 0, len = data.length; i < len; i++) {
-            var type = EntityTypes[data[i].t];
+            var type = EntityTypes[data[i][0]];
             if (type === undefined) continue;
             
-            var element = document.getElementById("y" + data[i].y + "x" + data[i].x);
+            var element = document.getElementById("y" + data[i][2] + "x" + data[i][1]);
             if (element == null) continue;
             
             element.classList.add(type);
             if (type === "Bomb") {
-                element.innerHTML = data[i].d;
+                element.innerHTML = data[i][3];
             }
         }
     } else {
         if (gEntities !== null) {
             //Remove the old data
             for (var i = 0, len = gEntities.length; i < len; i++) {
-                var type = EntityTypes[gEntities[i].t];
+                var type = EntityTypes[gEntities[i][0]];
                 if (type === undefined) continue;
                 
-                $(document.getElementById("y" + gEntities[i].y + "x" + gEntities[i].x)).removeClass(type);
+                $(document.getElementById("y" + gEntities[i][2] + "x" + gEntities[i][1])).removeClass(type);
                 if (type === "Bomb") {
                     element.innerHTML = "";
                 }
@@ -313,12 +313,12 @@ function updateEntities(data) {
         }
         
         for (var i = 0, len = data.length; i < len; i++) {
-            var type = EntityTypes[data[i].t];
+            var type = EntityTypes[data[i][0]];
             if (type === undefined) continue;
             
-            $(document.getElementById("y" + data[i].y + "x" + data[i].x)).addClass(type);
+            $(document.getElementById("y" + data[i][2] + "x" + data[i][1])).addClass(type);
             if (type === "Bomb") {
-                element.innerHTML = data[i].d;
+                element.innerHTML = data[i][3];
             }
         }
     }

--- a/src/test/java/nl/tudelft/contextproject/webinterface/util/EntityUtilTest.java
+++ b/src/test/java/nl/tudelft/contextproject/webinterface/util/EntityUtilTest.java
@@ -6,6 +6,7 @@ import nl.tudelft.contextproject.TestBase;
 import nl.tudelft.contextproject.model.entities.Entity;
 import nl.tudelft.contextproject.model.entities.exploding.Bomb;
 import nl.tudelft.contextproject.model.entities.moving.VRPlayer;
+import nl.tudelft.contextproject.model.entities.util.EntityType;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -14,7 +15,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.json.JSONArray;
-import org.json.JSONObject;
 
 /**
  * Class for testing the EntityUtil.
@@ -42,10 +42,11 @@ public class EntityUtilTest extends TestBase {
 	@Test
 	public void testEntityToJson() {
 		Bomb bomb = new Bomb();
-		JSONObject json = EntityUtil.entityToJson(bomb);
-		assertEquals(json.getInt("x"), 0);
-		assertEquals(json.getInt("y"), 0);
-		assertEquals(json.getInt("t"), 1);
-		assertEquals(json.getInt("d"), 0);
+		bomb.move(3, 0, 2);
+		JSONArray json = EntityUtil.entityToJson(bomb);
+		assertEquals(json.getInt(0), EntityType.BOMB.getWebId()); //Type
+		assertEquals(json.getInt(1), 3); //X
+		assertEquals(json.getInt(2), 2); //Y
+		assertEquals(json.getInt(3), 0); //Counter
 	}
 }


### PR DESCRIPTION
- Use Array instead of Object for entities, which saves 12 bytes/entity = 80 bytes per second per entity.
- Round the remaining time, to avoid useless long numbers like 3.4028234663852886E38
